### PR TITLE
Use etex instead of tex, do not reject VanillaTeX in present of \usepackage

### DIFF
--- a/tex2pdf_service/tex2pdf/tex_inspection.py
+++ b/tex2pdf_service/tex2pdf/tex_inspection.py
@@ -329,7 +329,12 @@ def is_pdftex_line(line: str)-> bool:
 
 def is_pdflatex_line(line: str)-> bool:
     """Check if the line is a pdftex line"""
-    return line.startswith('\\documentclass') or line.startswith('\\usepackage')
+    # Do not check for \usepackage since etex allows
+    # \beginpackages
+    #    \usepackage{...}
+    # \endpackages
+    # return line.startswith('\\documentclass') or line.startswith('\\usepackage')
+    return line.startswith('\\documentclass')
 
 
 _tex_input_1 = re.compile(r'\\input\{([^}]+)}')

--- a/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
+++ b/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
@@ -712,7 +712,7 @@ class VanillaTexConverter(BaseDviConverter):
         # pdf_filename = os.path.join(in_dir, stem_pdf)
         outcome: dict[str, typing.Any] = {"pdf_file": f"{stem_pdf}", "tex_file": tex_file}
 
-        args = ["/usr/bin/tex", "-interaction=batchmode", "-recorder"]
+        args = ["/usr/bin/etex", "-interaction=batchmode", "-recorder"]
         if WITH_SHELL_ESCAPE:
             args.append("-shell-escape")
         args.append(tex_file)


### PR DESCRIPTION
The `tex` interpreter is plain tex without any extension, but documents often
expect the e-TeX extensions being available. Use `etex` instead of `tex` as driver
for VanillaTeX.

Do not reject VanillaTeX in the presence of \usepackage, but only in the presence
of \documentclass, because etex allows
```
\beginpackages
   \usepackage{...}
\endpackages
```
for some packages.