### PR TITLE
Factorize base engine run into one function

### DIFF
--- a/tex2pdf_service/Appliance.Dockerfile
+++ b/tex2pdf_service/Appliance.Dockerfile
@@ -24,6 +24,7 @@ COPY texlive/2023/texmf.cnf .
 # apply necessary patches
 COPY texlive/2023/patches/ ./patches
 RUN patch -p0 <patches/0001-pdftex-def.patch
+RUN rm -rf patches
 RUN chown -R worker texmf.cnf ./texmf-arxiv/ ./texmf-local/
 
 USER worker

--- a/tex2pdf_service/Appliance.Dockerfile
+++ b/tex2pdf_service/Appliance.Dockerfile
@@ -21,6 +21,9 @@ WORKDIR /usr/local/texlive/2023
 COPY texlive/2023/texmf-arxiv/ ./texmf-arxiv/
 COPY texlive/2023/texmf-local/ ./texmf-local/
 COPY texlive/2023/texmf.cnf .
+# apply necessary patches
+COPY texlive/2023/patches/ ./patches
+RUN patch -p0 <patches/0001-pdftex-def.patch
 RUN chown -R worker texmf.cnf ./texmf-arxiv/ ./texmf-local/
 
 USER worker

--- a/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
+++ b/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
@@ -480,6 +480,8 @@ class LatexConverter(BaseDviConverter):
         logger = get_logger()
 
         outcome = self._run_base_engine_necessary_times(tex_file, work_dir, in_dir, out_dir, "dvi")
+        if outcome["status"] == "fail":
+            return outcome
 
         # Third - run dvips
         outcome, run = self._two_try_dvi_to_ps_run(outcome, self.stem, work_dir, in_dir, out_dir)

--- a/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
+++ b/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
@@ -78,7 +78,7 @@ class BaseConverter:
         pass
 
     @abstractmethod
-    def _base_runner(self, tex_file:str, work_dir: str, in_dir: str, out_dir: str) -> dict:
+    def _base_runner(self, step: str, tex_file:str, work_dir: str, in_dir: str, out_dir: str) -> dict:
         """Run the base engine of the converter."""
         pass
 
@@ -496,13 +496,13 @@ class LatexConverter(BaseDviConverter):
         logger.debug("latex.produce_pdf", extra={ID_TAG: self.conversion_tag, "outcome": outcome})
         return outcome
 
-    def _latex_run(self, tag: str, tex_file: str, work_dir: str, in_dir: str, _out_dir: str) -> dict:
+    def _latex_run(self, step: str, tex_file: str, work_dir: str, in_dir: str, out_dir: str) -> dict:
         # breaks many packages... f"-output-directory=../{bod}"
         args = ["/usr/bin/latex", "-interaction=batchmode", "-file-line-error", "-recorder"]
         if WITH_SHELL_ESCAPE:
             args.append("-shell-escape")
         args.append(tex_file)
-        return self._base_to_dvi_run(tag, self.stem, args, work_dir, in_dir)
+        return self._base_to_dvi_run(step, self.stem, args, work_dir, in_dir)
     
     _base_runner = _latex_run
 


### PR DESCRIPTION
To unify treatment of multiple runs necessary between LatexConverter and PDFLatexConverter, factor the run loop into a separate function that is called from generate_pdf.