### PR TITLE
[UNDER DISCUSSION] Allow setting some TEXMF env vars via URL parameters

### DIFF
--- a/tex2pdf_service/tex2pdf/__init__.py
+++ b/tex2pdf_service/tex2pdf/__init__.py
@@ -23,7 +23,7 @@ MAX_LATEX_RUNS: int = int(os.environ.get("MAX_LATEX_RUNS", "5"))
 # Log level name may be different depending on the service provider
 LOG_LEVEL_NAME = os.environ.get("LOG_LEVEL_NAME", "severity")
 
-USE_ADDON_TREE: bool = os.environ.get("USE_ADDON_TREE") in ["y", "true"]
+TEXMF_ADDON_TREES: list[str] = os.environ.get("TEXMF_ADDON_TREES", "").split(",")
 
 
 class CustomJsonFormatter(JsonFormatter):

--- a/tex2pdf_service/tex2pdf/__init__.py
+++ b/tex2pdf_service/tex2pdf/__init__.py
@@ -23,8 +23,12 @@ MAX_LATEX_RUNS: int = int(os.environ.get("MAX_LATEX_RUNS", "5"))
 # Log level name may be different depending on the service provider
 LOG_LEVEL_NAME = os.environ.get("LOG_LEVEL_NAME", "severity")
 
-TEXMF_ADDON_TREES: list[str] = os.environ.get("TEXMF_ADDON_TREES", "").split(",")
-
+TEXMF_ENV_VARS: list[str] = os.environ.get("TEXMF_ENV_VARS", "").split(",")
+ALLOWED_TEXMF_ENV_VARS: list[str] = [
+    "TEXMFAUXTREES",
+    "SOURCE_DATE_EPOCH",
+    "FORCE_SOURCE_DATE",
+]
 
 class CustomJsonFormatter(JsonFormatter):
     """Logging formatter to play nice with JSON logger"""

--- a/tex2pdf_service/tex2pdf/__init__.py
+++ b/tex2pdf_service/tex2pdf/__init__.py
@@ -23,7 +23,7 @@ MAX_LATEX_RUNS: int = int(os.environ.get("MAX_LATEX_RUNS", "5"))
 # Log level name may be different depending on the service provider
 LOG_LEVEL_NAME = os.environ.get("LOG_LEVEL_NAME", "severity")
 
-TEXMF_ENV_VARS: list[str] | None = os.environ.get("TEXMF_ENV_VARS").split(",") if os.environ.get("TEXMF_ENV_VARS") else None
+TEXMF_ENV_VARS: list[str] | None = os.environ.get("TEXMF_ENV_VARS", "").split(",") if os.environ.get("TEXMF_ENV_VARS") else None
 ALLOWED_TEXMF_ENV_VARS: list[str] = [
     "TEXMFAUXTREES",
     "SOURCE_DATE_EPOCH",

--- a/tex2pdf_service/tex2pdf/__init__.py
+++ b/tex2pdf_service/tex2pdf/__init__.py
@@ -23,7 +23,7 @@ MAX_LATEX_RUNS: int = int(os.environ.get("MAX_LATEX_RUNS", "5"))
 # Log level name may be different depending on the service provider
 LOG_LEVEL_NAME = os.environ.get("LOG_LEVEL_NAME", "severity")
 
-TEXMF_ENV_VARS: list[str] = os.environ.get("TEXMF_ENV_VARS", "").split(",")
+TEXMF_ENV_VARS: list[str] | None = os.environ.get("TEXMF_ENV_VARS").split(",") if os.environ.get("TEXMF_ENV_VARS") else None
 ALLOWED_TEXMF_ENV_VARS: list[str] = [
     "TEXMFAUXTREES",
     "SOURCE_DATE_EPOCH",

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -49,9 +49,9 @@ class ConverterDriver:
     converter_logs: typing.List[str]
     tag: str
     note: str
-    texmf_addon_trees: list[str]
+    texmf_env_vars: dict[str, str]
 
-    def __init__(self, work_dir: str, source: str, texmf_addon_trees: list[str] = [],
+    def __init__(self, work_dir: str, source: str, texmf_env_vars: dict[str, str] = {},
                  tag: str | None = None, water: str | None = None,
                  max_time_budget: float | None = None):
         self.work_dir = work_dir
@@ -69,7 +69,7 @@ class ConverterDriver:
         self.t0 = time.perf_counter()
         self.max_time_budget = MAX_TIME_BUDGET if max_time_budget is None else max_time_budget
         self.tag = tag if tag else "unknown driver"
-        self.texmf_addon_trees = texmf_addon_trees
+        self.texmf_env_vars = texmf_env_vars
         pass
 
     @property
@@ -90,7 +90,7 @@ class ConverterDriver:
                         "timeout": str(self.max_time_budget),
                         "watermark": self.water,
                         "zzrm": self.zzrm.readme,
-                        "texmf_addon_trees": self.texmf_addon_trees}
+                        "texmf_env_vars": self.texmf_env_vars}
         # Find the starting point
         fix_tex_sources(self.in_dir)
         self.tex_files = find_primary_tex(self.in_dir, self.zzrm)
@@ -140,7 +140,7 @@ class ConverterDriver:
             outcome["pdf_files"] = []
             outcome["include_figures"] = converter_class.yes_pix()
             for tex_file in ordered_tex_files:
-                self.converter = converter_class(self.tag, texmf_addon_trees=self.texmf_addon_trees,
+                self.converter = converter_class(self.tag, texmf_env_vars=self.texmf_env_vars,
                                                  zzrm=self.zzrm, init_time=self.t0,
                                                  max_time_budget=self.max_time_budget)
                 cpu_t0 = time.process_time()

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -49,9 +49,9 @@ class ConverterDriver:
     converter_logs: typing.List[str]
     tag: str
     note: str
-    use_addon_tree: bool
+    texmf_addon_trees: list[str]
 
-    def __init__(self, work_dir: str, source: str, use_addon_tree: bool | None = None,
+    def __init__(self, work_dir: str, source: str, texmf_addon_trees: list[str] = [],
                  tag: str | None = None, water: str | None = None,
                  max_time_budget: float | None = None):
         self.work_dir = work_dir
@@ -69,7 +69,7 @@ class ConverterDriver:
         self.t0 = time.perf_counter()
         self.max_time_budget = MAX_TIME_BUDGET if max_time_budget is None else max_time_budget
         self.tag = tag if tag else "unknown driver"
-        self.use_addon_tree = use_addon_tree if use_addon_tree else False
+        self.texmf_addon_trees = texmf_addon_trees
         pass
 
     @property
@@ -90,7 +90,7 @@ class ConverterDriver:
                         "timeout": str(self.max_time_budget),
                         "watermark": self.water,
                         "zzrm": self.zzrm.readme,
-                        "use_addon_tree": self.use_addon_tree}
+                        "texmf_addon_trees": self.texmf_addon_trees}
         # Find the starting point
         fix_tex_sources(self.in_dir)
         self.tex_files = find_primary_tex(self.in_dir, self.zzrm)
@@ -140,7 +140,7 @@ class ConverterDriver:
             outcome["pdf_files"] = []
             outcome["include_figures"] = converter_class.yes_pix()
             for tex_file in ordered_tex_files:
-                self.converter = converter_class(self.tag, use_addon_tree=self.use_addon_tree,
+                self.converter = converter_class(self.tag, texmf_addon_trees=self.texmf_addon_trees,
                                                  zzrm=self.zzrm, init_time=self.t0,
                                                  max_time_budget=self.max_time_budget)
                 cpu_t0 = time.process_time()

--- a/tex2pdf_service/tex2pdf/tex2pdf_api.py
+++ b/tex2pdf_service/tex2pdf/tex2pdf_api.py
@@ -85,7 +85,7 @@ def healthcheck() -> str:
              STATCODE.HTTP_500_INTERNAL_SERVER_ERROR: {"model": Message}
          })
 async def convert_pdf(incoming: UploadFile,
-                      texmf_addon_trees: typing.Annotated[list[str] | None,
+                      texmf_addon_trees: typing.Annotated[list[str],
                                                        Query(title="Addon tree(s)",
                                                              description="Adds argument as addon texmf tree.")] = TEXMF_ADDON_TREES,
                       timeout: typing.Annotated[int | None,

--- a/tex2pdf_service/tex2pdf/tex2pdf_api.py
+++ b/tex2pdf_service/tex2pdf/tex2pdf_api.py
@@ -137,8 +137,8 @@ async def convert_pdf(incoming: UploadFile,
                 key, val = assignment.split("=", 1)
                 if key not in ALLOWED_TEXMF_ENV_VARS:
                     logger.info("Environment variable not allowed: %s", key)
-                    JSONResponse(status_code=STATCODE.HTTP_400_BAD_REQUEST,
-                                 content={"message": f"Environment variable not allowed: {key}"})
+                    return JSONResponse(status_code=STATCODE.HTTP_400_BAD_REQUEST,
+                                        content={"message": f"Environment variable not allowed: {key}"})
                 texmf_env_vars_parsed[key] = shlex.quote(val)
         driver = ConverterDriver(tempdir, filename, texmf_env_vars=texmf_env_vars_parsed, tag=tag,
                                  water=watermark_text, max_time_budget=timeout_secs,

--- a/tex2pdf_service/tex2pdf/tex2pdf_api.py
+++ b/tex2pdf_service/tex2pdf/tex2pdf_api.py
@@ -14,7 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import HTMLResponse, FileResponse
 from pydantic import BaseModel
 
-from tex2pdf import MAX_TIME_BUDGET, USE_ADDON_TREE
+from tex2pdf import MAX_TIME_BUDGET, TEXMF_ADDON_TREES
 from tex2pdf.converter_driver import ConverterDriver, ConversionOutcomeMaker
 from tex2pdf.service_logger import get_logger
 from tex2pdf.tarball import save_stream, prep_tempdir, RemovedSubmission, UnsupportedArchive
@@ -85,9 +85,9 @@ def healthcheck() -> str:
              STATCODE.HTTP_500_INTERNAL_SERVER_ERROR: {"model": Message}
          })
 async def convert_pdf(incoming: UploadFile,
-                      use_addon_tree: typing.Annotated[bool,
-                                                       Query(title="Use addon tree",
-                                                             description="Determines whether an addon tree is used.")] = USE_ADDON_TREE,
+                      texmf_addon_trees: typing.Annotated[list[str] | None,
+                                                       Query(title="Addon tree(s)",
+                                                             description="Adds argument as addon texmf tree.")] = TEXMF_ADDON_TREES,
                       timeout: typing.Annotated[int | None,
                                                 Query(title="Time out",
                                                       description="Time out in seconds.")] = None,
@@ -117,7 +117,7 @@ async def convert_pdf(incoming: UploadFile,
             except ValueError:
                 pass
             pass
-        driver = ConverterDriver(tempdir, filename, use_addon_tree=use_addon_tree, tag=tag,
+        driver = ConverterDriver(tempdir, filename, texmf_addon_trees=texmf_addon_trees, tag=tag,
                                  water=watermark_text, max_time_budget=timeout_secs)
         try:
             _pdf_file = driver.generate_pdf()

--- a/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
+++ b/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
@@ -173,16 +173,17 @@ class BaseConverter:
                         if not os.path.exists(t):
                             raise BadTexmfTree(f"{t} directory does not exist")
                     # update TEXMFAUXTREES value to have a final ","
-                    self.texmf_env_vars[key] = val.rstrip(",") + ","
+                    cmdenv[key] = val.rstrip(",") + ","
                 elif key == "SOURCE_DATE_EPOCH":
-                    # this value must be an integer >=0 
+                    # this value must be an integer >=0
                     if not val.isdecimal():
                         raise ValueError(f"Value for SOURCE_DATE_EPOCH must be a non-negative integer, not {val}")
+                    cmdenv[key] = val
                 elif key == "FORCE_SOURCE_DATE":
                     if val not in ["0", "1"]:
                         raise ValueError(f"Value of FORCE_SOURCE_DATE must be either 0 or 1, not {val}")
-                # still here, so all fine -- the val are already shell quoted at api entry point
-                cmdenv[key] = val
+                    cmdenv[key] = val
+        logger.debug("Running subprocess with cmdenv = {cmdenv}")
         with subprocess.Popen(worker_args, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
                               cwd=child_dir, encoding='iso-8859-1', env=cmdenv) as child:
             process_completion = False


### PR DESCRIPTION
Instead of only allowing TEXMFAUXTREES, allow setting env vars from a list of allowed values, at the moment:
TEXMFAUXTREES
SOURCE_DATE_EPOCH
FORCE_SOURCE_DATE

Used by https://github.com/arXiv/arxiv-converter/pull/65