### PR TITLE
Add detection of incorrect graphics extension log line

### DIFF
--- a/tex2pdf_service/tex2pdf/log_inspection.py
+++ b/tex2pdf_service/tex2pdf/log_inspection.py
@@ -21,6 +21,7 @@ TEX_LOG_ERRORS: typing.List[Pattern] = [
         r': File `(.*)\' not found:\s*$',
         r'! Unable to load picture or PDF file \'([^\\\']+)\'.',
         r'Package pdftex.def Error: File (.*) not found: using draft setting\.',
+        r'.*?:\d*: LaTeX Error:  Unknown graphics extension: (.*)\.',
     ]
 ]
 

--- a/tex2pdf_service/tex2pdf/log_inspection.py
+++ b/tex2pdf_service/tex2pdf/log_inspection.py
@@ -21,7 +21,7 @@ TEX_LOG_ERRORS: typing.List[Pattern] = [
         r': File `(.*)\' not found:\s*$',
         r'! Unable to load picture or PDF file \'([^\\\']+)\'.',
         r'Package pdftex.def Error: File (.*) not found: using draft setting\.',
-        r'.*?:\d*: LaTeX Error:  Unknown graphics extension: (.*)\.',
+        r'.*?:\d*: LaTeX Error: Unknown graphics extension: (.*)\.',
     ]
 ]
 


### PR DESCRIPTION
Fixes incorrect use of pdflatex converter when .ps/.eps files are included.
With this fix, log lines like:
```
LaTeX Error: Unknown graphics extension: .ps.
```
will be detected and the pdflatex run be rejected, triggering another run
with latex converter that succeeds.

Tested with set of 105 submission containing 4 cases that are detected and fixed.
