### PR TITLE
Fixed (1) removing quotes from file name (2) widen not-found detection (3) List all missing files

### DIFF
--- a/tex2pdf_service/tex2pdf/log_inspection.py
+++ b/tex2pdf_service/tex2pdf/log_inspection.py
@@ -20,11 +20,13 @@ TEX_LOG_ERRORS: typing.List[Pattern] = [
         r'Error: pdflatex \(file ([^\)]*)\): cannot find image file',
         r': File `(.*)\' not found:\s*$',
         r'! Unable to load picture or PDF file \'([^\\\']+)\'.',
-        r'Package pdftex.def Error: File (.*) not found: using draft setting\.',
+        r'def Error: File `(.*)\' not found: using draft setting\.',
         r'.*?:\d*: LaTeX Error: Unknown graphics extension: (.*)\.',
     ]
 ]
 
+# There is a log
+# \n ....def Error: File `\\Gin@base .pdf' not found: using draft setting
 
 def inspect_log(log: str,
                 patterns: typing.List[Pattern] | None = None,

--- a/tex2pdf_service/tex2pdf/log_inspection.py
+++ b/tex2pdf_service/tex2pdf/log_inspection.py
@@ -20,13 +20,13 @@ TEX_LOG_ERRORS: typing.List[Pattern] = [
         r'Error: pdflatex \(file ([^\)]*)\): cannot find image file',
         r': File `(.*)\' not found:\s*$',
         r'! Unable to load picture or PDF file \'([^\\\']+)\'.',
-        r'def Error: File `(.*)\' not found: using draft setting\.',
+        r'Error: File `(.*)\' not found: using draft setting\.',
         r'.*?:\d*: LaTeX Error: Unknown graphics extension: (.*)\.',
     ]
 ]
 
 # There is a log
-# \n ....def Error: File `\\Gin@base .pdf' not found: using draft setting
+# \n ....def Error: File `\\Gin@base .pdf' not found: using draft setting.\n
 
 def inspect_log(log: str,
                 patterns: typing.List[Pattern] | None = None,

--- a/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
+++ b/tex2pdf_service/tex2pdf/tex_to_pdf_converters.py
@@ -301,7 +301,7 @@ class BaseConverter:
         """Scoop up the missing files from the tex command log"""
         name = run[artifact]["name"]
         artifact_file = os.path.join(in_dir, name)
-        if os.path.exists(artifact_file) and (missings := inspect_log(run["log"])):
+        if os.path.exists(artifact_file) and (missings := inspect_log(run["log"], break_on_found=False)):
             run["missings"] = missings
             get_logger().debug(f"Output {name} deleted due to incomplete run.")
             os.unlink(artifact_file)


### PR DESCRIPTION
Before :
```
          "missings": [
            "`splitsquash-eps-converted-to.pdf'"
          ]

```

After:
```
          "missings": [
            "\\Gin@base .pdf",
            "splitsquash-eps-converted-to.pdf",
            "rmassiveJD10-eps-converted-to.pdf",
            "rmassiveJD4-eps-converted-to.pdf",
            "curvclasSQ2-eps-converted-to.pdf",
            "lfmassivesqD4-eps-converted-to.pdf",
            "rateclosed-eps-converted-to.pdf",
            "lfmassivesqD10-eps-converted-to.pdf",
            "JmxSq-eps-converted-to.pdf",
            "rateopen-eps-converted-to.pdf"
          ]

```