### PR TITLE
Allow clickable links in watermark

### DIFF
--- a/tex2pdf_service/tests/test_watermark.py
+++ b/tex2pdf_service/tests/test_watermark.py
@@ -19,7 +19,7 @@ class MyTestCase(unittest.TestCase):
             self.assertTrue(pdfd.read(4) == b"%PDF")
 
     def test_watermarking(self):
-        add_watermark_text_to_pdf("Water World is in Orlando, FL.", in_pdf,
+        add_watermark_text_to_pdf("""<link href="https://en.wikipedia.org/wiki/Waterworld">Water World</link> is in Orlando, FL.""", in_pdf,
                                    "tests/test-output/Test.pdf")
 
 if __name__ == '__main__':

--- a/tex2pdf_service/tex2pdf/pdf_watermark.py
+++ b/tex2pdf_service/tex2pdf/pdf_watermark.py
@@ -103,8 +103,8 @@ def add_watermark_text_to_pdf(watermark: str,
             destination_page = source.pages[0]
             indirect_annots = overlay.make_indirect(source_page.Annots)
             if '/Annots' in destination_page:
-                # TODO needs testing!!!
-                destination_page.Annots.append(source.copy_foreign(indirect_annots))
+                # only copy the first (and only) annotation into the origins list of annots
+                destination_page.Annots.append(source.copy_foreign(indirect_annots[0]))
             else:
                 destination_page.Annots = source.copy_foreign(indirect_annots)
             destination_page.add_overlay(pikepdf.Page(source_page))  # type: ignore

--- a/tex2pdf_service/tex2pdf/pdf_watermark.py
+++ b/tex2pdf_service/tex2pdf/pdf_watermark.py
@@ -16,6 +16,7 @@ import reportlab.lib.units
 from reportlab.pdfgen.textobject import PDFTextObject
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.platypus import Paragraph
+from reportlab.lib.enums import TA_CENTER
 
 # This is how it is done in arxiv-lib/lib/TeX/AutoTeX/StampPDF.pm
 #
@@ -56,24 +57,31 @@ def gen_watermark_pdf(watermark: str, in_pdf: pathlib.Path | str, out_pdf: str) 
         pass
     canvas = reportlab.pdfgen.canvas.Canvas(out_pdf, pagesize=page_size)
     canvas.setFont('Times-Roman', 20)
-    wm_style = ParagraphStyle(
-        fontName = "Times-Roman",
-        fontSize = 20,
-        textColor = "#7f7f7f",
-    )
+
+    # This method does not support links!
     # canvas.drawString(32, 32, watermark)
     # text = PDFTextObject(canvas)
     # text.setFillGray(0.5)
     # text.setStrokeGray(0.5)
     # text.setFont('Times-Roman', 20)
-    y_offset = 432 - 5 * len(watermark)
+    # y_offset = 432 - 5 * len(watermark)
     # text.setTextTransform(0, 1, -1, 0, 32, y_offset)
     # text.textLine(watermark)
     # canvas.drawText(text)
-    p = Paragraph(watermark)
-    canvas.transform(0, 1, -1, 0, 32, y_offset)
-    p.wrapOn(canvas, 1000, 1000)
-    p.drawOn(canvas, 0, 0)
+
+    wm_style = ParagraphStyle('watermark_style',
+        fontName = "Times-Roman",
+        fontSize = 20,
+        align=TA_CENTER,
+        textColor = "#7f7f7f",
+    )
+    p = Paragraph(watermark, wm_style)
+    canvas.transform(0, 1, -1, 0, 32, 0)
+    # wrap on huge size so that we have only one line
+    p.wrap(7200,7200)
+    actual_width = p.getActualLineWidths0()[0]
+    p.wrapOn(canvas, page_size[0], page_size[1])
+    p.drawOn(canvas, (page_size[1] - actual_width)/2, 0)
     canvas.save()
     pass
 

--- a/tex2pdf_service/tex2pdf/pdf_watermark.py
+++ b/tex2pdf_service/tex2pdf/pdf_watermark.py
@@ -14,6 +14,8 @@ import reportlab.pdfgen.canvas
 import reportlab.lib.pagesizes
 import reportlab.lib.units
 from reportlab.pdfgen.textobject import PDFTextObject
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.platypus import Paragraph
 
 # This is how it is done in arxiv-lib/lib/TeX/AutoTeX/StampPDF.pm
 #
@@ -54,15 +56,24 @@ def gen_watermark_pdf(watermark: str, in_pdf: pathlib.Path | str, out_pdf: str) 
         pass
     canvas = reportlab.pdfgen.canvas.Canvas(out_pdf, pagesize=page_size)
     canvas.setFont('Times-Roman', 20)
+    wm_style = ParagraphStyle(
+        fontName = "Times-Roman",
+        fontSize = 20,
+        textColor = "#7f7f7f",
+    )
     # canvas.drawString(32, 32, watermark)
-    text = PDFTextObject(canvas)
-    text.setFillGray(0.5)
-    text.setStrokeGray(0.5)
-    text.setFont('Times-Roman', 20)
+    # text = PDFTextObject(canvas)
+    # text.setFillGray(0.5)
+    # text.setStrokeGray(0.5)
+    # text.setFont('Times-Roman', 20)
     y_offset = 432 - 5 * len(watermark)
-    text.setTextTransform(0, 1, -1, 0, 32, y_offset)
-    text.textLine(watermark)
-    canvas.drawText(text)
+    # text.setTextTransform(0, 1, -1, 0, 32, y_offset)
+    # text.textLine(watermark)
+    # canvas.drawText(text)
+    p = Paragraph(watermark)
+    canvas.transform(0, 1, -1, 0, 32, y_offset)
+    p.wrapOn(canvas, 1000, 1000)
+    p.drawOn(canvas, 0, 0)
     canvas.save()
     pass
 


### PR DESCRIPTION
Use Paragraph with styles instead of directly adding text to allow links to be supported.

This also changes the computation of the length of the text box by actually laying it out
and thus correctly centering on the page.