### PR TITLE
Change merging of documents to use Ghostscript to preserve links

### DIFF
--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -371,6 +371,10 @@ Note that adding a 00README.XXX with a toplevelfile directive will only effect t
         except AssemblingFileNotFound as exc:
             logger.warning("Failed combining PDFs: %s", exc, extra=self.log_extra)
             pass
+        except subprocess.TimeoutExpired:
+            logger.warning("Failed combining PDFs: gs call timed out", extra=self.log_extra)
+        except subprocess.CalledProcessError:
+            logger.warning("Failed combining PDFs: gs returned an error", extra=self.log_extra)
 
         if self.water and (not self.zzrm.nostamp):
             pdf_file = os.path.join(self.out_dir, outcome["pdf_file"])

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -360,8 +360,9 @@ Note that adding a 00README.XXX with a toplevelfile directive will only effect t
             # Docs decided
             outcome["documents"] = docs
             docs = [os.path.join(self.work_dir, doc) for doc in docs]
-            final_pdf, used_gfx, unused_gfx = \
+            final_pdf, used_gfx, unused_gfx, addon_outcome = \
                 combine_documents(docs, self.out_dir, merged_pdf, log_extra=self.log_extra)
+            outcome |= addon_outcome
             self.zzrm.set_assembling_files(used_gfx)
             outcome["pdf_file"] = final_pdf
             outcome["used_figures"] = used_gfx
@@ -372,10 +373,10 @@ Note that adding a 00README.XXX with a toplevelfile directive will only effect t
         except AssemblingFileNotFound as exc:
             logger.warning("Failed combining PDFs: %s", exc, extra=self.log_extra)
             pass
-        except subprocess.TimeoutExpired:
-            logger.warning("Failed combining PDFs: gs call timed out", extra=self.log_extra)
-        except subprocess.CalledProcessError:
-            logger.warning("Failed combining PDFs: gs returned an error", extra=self.log_extra)
+        except subprocess.TimeoutExpired as exc:
+            logger.warning("Failed combining PDFs: gs call timed out: %s", exc, extra=self.log_extra)
+        except subprocess.CalledProcessError as exc:
+            logger.warning("Failed combining PDFs: gs returned an error: %s", exc, extra=self.log_extra)
 
         if self.water and (not self.zzrm.nostamp):
             pdf_file = os.path.join(self.out_dir, outcome["pdf_file"])

--- a/tex2pdf_service/tex2pdf/doc_converter.py
+++ b/tex2pdf_service/tex2pdf/doc_converter.py
@@ -45,7 +45,7 @@ def combine_documents(doc_list: typing.List[str], out_dir: str, out_filename: st
     output_path = os.path.join(out_dir, out_filename)
     converted_docs: typing.List[str] = []
     failed_docs: typing.List[str] = []
-    addon_outcome: typing.Dict[str,dict[str,str]] = {}
+    addon_outcome: typing.Dict[str,dict] = {}
     # if we have only one pdf document in the list, return it as is
     if len(doc_list) == 1 and doc_list[0].lower().endswith(".pdf"):
         if doc_list[0] != output_path:
@@ -101,4 +101,5 @@ def combine_documents(doc_list: typing.List[str], out_dir: str, out_filename: st
     addon_outcome['gs'] = {}
     addon_outcome['gs']['stdout'] = ret.stdout
     addon_outcome['gs']['stderr'] = ret.stderr
+    addon_outcome['gs']['return_code'] = ret.returncode
     return out_filename, strip_to_basename(converted_docs), strip_to_basename(failed_docs), addon_outcome

--- a/tex2pdf_service/tex2pdf/doc_converter.py
+++ b/tex2pdf_service/tex2pdf/doc_converter.py
@@ -77,10 +77,10 @@ def combine_documents(doc_list: typing.List[str], out_dir: str, out_filename: st
                                exc_info=True)
     # call gs to combine the pdf
     # we cannot use pikepdf (easily) here since it breaks annotations (links)
-    # gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER -sOutputFile=merged-ps.pdf  ms.pdf supp.pdf
     gs_cmd = [
         "gs", "-sDEVICE=pdfwrite", "-dNOPAUSE", "-dBATCH", "-dSAFER", f"-sOutputFile={output_path}"
     ] + effective_pdf_list
     logger.debug("Running gs to combine pdfs: %s", shlex.join(gs_cmd), extra=log_extra)
-    subprocess.call(gs_cmd)
+    # exception handing is done in convert_driver:_finalize_pdf
+    subprocess.run(gs_cmd, timeout=30, check=True)
     return out_filename, strip_to_basename(converted_docs), strip_to_basename(failed_docs)


### PR DESCRIPTION
See https://arxiv-org.atlassian.net/browse/ARXIVCE-753

Using pikepdf to merge pdfs destoys annotations, that is links.
Similarly, using pdfpages (as autotex does) also destroys annotations.
Options to combine with preservance of annots/links are
- gs (implemented here)
- external command pdftk
