### PR TITLE
ruff/pre-commit enabling for preflight_parser

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+files: preflight_parser
+
+default_language_version:
+  python: python3.11
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+

--- a/preflight_parser/pyproject.toml
+++ b/preflight_parser/pyproject.toml
@@ -9,41 +9,15 @@ include = ["kpse_search.lua"]
 [tool.poetry.dependencies]
 chardet = "^5.0"
 
-[project.optional-dependencies]
-dev = [
-  "ruff",
-]
+[tool.poetry.group.dev.dependencies]
+ruff = "*"
+pytest = "^7.4.3"
+mypy = "*"
+mypy-extensions = "*"
 
 [tool.ruff]
-line-length = 120
-
-lint.select = [
-    "F", # Pyflakes
-    "D", # pydocstyle
-    "E", # pycodestyle errors
-    # "W", # pycodestyle warnings
-    # "C90", # McCabe
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PLC",
-    "PLE",
-    "PLW", # Pylint
-    # "PLR", # Pylint refactoring
-    "PD",  # pandas checks
-    "NPY", # numpy checks
-    "RUF", # ruff internal check
-]
-lint.ignore = [
-    "D105", # no docstring in magic method like __str__
-    "D203", # one blank line before class
-    "D213", # multi-line summary second line
-]
-
-output-format = "grouped"
-
-# Assume Python 3.11
-# Note: helps prevent breaking autofixes from, e.g., pyupgrade
-target-version = "py311"
+# Extend the `pyproject.toml` from the toplevel dir
+extend = "../pyproject.toml"
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[tool.ruff]
+line-length = 120
+
+
+lint.select = [
+    "F", # Pyflakes
+    "D", # pydocstyle
+    "E", # pycodestyle errors
+    # "W", # pycodestyle warnings
+    # "C90", # McCabe
+    "I",   # isort
+    "UP",  # pyupgrade
+    "PLC",
+    "PLE",
+    "PLW", # Pylint
+    # "PLR", # Pylint refactoring
+    "PD",  # pandas checks
+    "NPY", # numpy checks
+    "RUF", # ruff internal check
+]
+lint.ignore = [
+    "D105", # no docstring in magic method like __str__
+    "D203", # one blank line before class
+    "D213", # multi-line summary second line
+]
+
+output-format = "grouped"
+
+# Assume Python 3.11
+# Note: helps prevent breaking autofixes from, e.g., pyupgrade
+target-version = "py311"
+
+[tool.black]
+line-length = 120
+
+[tool.pylint]
+max-line-length = 120
+


### PR DESCRIPTION
- add a common pyproject.toml with ruff settings to the root
- extend the ruff section in preflight_parser/pyproject.toml using the root pyproject.toml
- add a pre-commit config file that enforces ruff check/format on pre-commit for preflight_parser