### PR TITLE
ARXIVCE-2614 Create remote converter driver

### DIFF
--- a/.github/workflows/tex2pdf.yaml
+++ b/.github/workflows/tex2pdf.yaml
@@ -25,6 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest poetry
         poetry install
+        poetry run pip install types-requests
     - name: pytest for tex2pdf
       run: |
         cd tex2pdf_service

--- a/tex2pdf_service/bin/compile_submissions.py
+++ b/tex2pdf_service/bin/compile_submissions.py
@@ -34,7 +34,7 @@ from multiprocessing.pool import ThreadPool
 from sqlite3 import Connection
 
 import click
-from tex2pdf.remote_call import submit_tarball
+from tex2pdf.remote_call import service_process_tarball
 from tqdm import tqdm
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s: %(message)s')
@@ -114,7 +114,7 @@ def compile(submissions: str, service: str, score: str, tex2pdf_timeout: int, po
     def local_submit_tarball(tarball: str) -> None:
         outcome_file = tarball_to_outcome_path(tarball)
         try:
-            submit_tarball(service, tarball, outcome_file, tex2pdf_timeout, post_timeout)
+            service_process_tarball(service, tarball, outcome_file, tex2pdf_timeout, post_timeout)
         except FileExistsError:
             logging.info(f"Not recreating already existing {outcome_file}.")
             pass

--- a/tex2pdf_service/poetry.lock
+++ b/tex2pdf_service/poetry.lock
@@ -773,7 +773,7 @@ pydantic = "==1.10.*"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "HEAD"
-resolved_reference = "e665aed7daa77794115fee23e306c5e148e2dcf2"
+resolved_reference = "4efa978094b6a125532b764ca0ba27103095c4b7"
 subdirectory = "preflight_parser"
 
 [[package]]
@@ -1154,7 +1154,7 @@ toml = "^0.10.2"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "HEAD"
-resolved_reference = "e665aed7daa77794115fee23e306c5e148e2dcf2"
+resolved_reference = "4efa978094b6a125532b764ca0ba27103095c4b7"
 subdirectory = "tex_inspection"
 
 [[package]]
@@ -1368,7 +1368,7 @@ tomli_w = "^1.0"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "HEAD"
-resolved_reference = "e665aed7daa77794115fee23e306c5e148e2dcf2"
+resolved_reference = "4efa978094b6a125532b764ca0ba27103095c4b7"
 subdirectory = "zerozeroreadme"
 
 [metadata]

--- a/tex2pdf_service/poetry.lock
+++ b/tex2pdf_service/poetry.lock
@@ -772,8 +772,8 @@ pydantic = "==1.10.*"
 [package.source]
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
-reference = "ARXIVCE-2542-use-new-preflight"
-resolved_reference = "eeb2327ef88cb77dcdd4e67099b58efb0effd6f2"
+reference = "HEAD"
+resolved_reference = "e665aed7daa77794115fee23e306c5e148e2dcf2"
 subdirectory = "preflight_parser"
 
 [[package]]
@@ -1153,8 +1153,8 @@ toml = "^0.10.2"
 [package.source]
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
-reference = "ARXIVCE-2542-use-new-preflight"
-resolved_reference = "eeb2327ef88cb77dcdd4e67099b58efb0effd6f2"
+reference = "HEAD"
+resolved_reference = "e665aed7daa77794115fee23e306c5e148e2dcf2"
 subdirectory = "tex_inspection"
 
 [[package]]
@@ -1359,7 +1359,7 @@ files = []
 develop = false
 
 [package.dependencies]
-preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", branch = "ARXIVCE-2542-use-new-preflight", subdirectory = "preflight_parser"}
+preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "preflight_parser"}
 ruamel-yaml = "^0.18.5"
 toml = "^0.10.2"
 tomli_w = "^1.0"
@@ -1367,11 +1367,11 @@ tomli_w = "^1.0"
 [package.source]
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
-reference = "ARXIVCE-2542-use-new-preflight"
-resolved_reference = "eeb2327ef88cb77dcdd4e67099b58efb0effd6f2"
+reference = "HEAD"
+resolved_reference = "e665aed7daa77794115fee23e306c5e148e2dcf2"
 subdirectory = "zerozeroreadme"
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "77933bd0b9d81ba27a6e04ff3ecbac247fb85d7df082aab5689dc28d3a5fc60b"
+content-hash = "8654f6602bc896c175fbf7d94828b2210804256c32baac483ec17a1266b0cf08"

--- a/tex2pdf_service/poetry.lock
+++ b/tex2pdf_service/poetry.lock
@@ -1374,4 +1374,4 @@ subdirectory = "zerozeroreadme"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "0c1af3c635b1a4126ef297582f6ccc758c7c291c42687cf562148b571d7fde19"
+content-hash = "77933bd0b9d81ba27a6e04ff3ecbac247fb85d7df082aab5689dc28d3a5fc60b"

--- a/tex2pdf_service/poetry.lock
+++ b/tex2pdf_service/poetry.lock
@@ -773,7 +773,7 @@ pydantic = "==1.10.*"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "ARXIVCE-2614-RemoteConverterDriver"
-resolved_reference = "3353f4a21e53ca8bda21e29cdb4a5b418c5d7075"
+resolved_reference = "e32ced058688a5fd7f9f84f06a4488f9ab65893d"
 subdirectory = "preflight_parser"
 
 [[package]]
@@ -1154,7 +1154,7 @@ toml = "^0.10.2"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "ARXIVCE-2614-RemoteConverterDriver"
-resolved_reference = "3353f4a21e53ca8bda21e29cdb4a5b418c5d7075"
+resolved_reference = "e32ced058688a5fd7f9f84f06a4488f9ab65893d"
 subdirectory = "tex_inspection"
 
 [[package]]
@@ -1368,7 +1368,7 @@ tomli_w = "^1.0"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "ARXIVCE-2614-RemoteConverterDriver"
-resolved_reference = "3353f4a21e53ca8bda21e29cdb4a5b418c5d7075"
+resolved_reference = "e32ced058688a5fd7f9f84f06a4488f9ab65893d"
 subdirectory = "zerozeroreadme"
 
 [metadata]

--- a/tex2pdf_service/poetry.lock
+++ b/tex2pdf_service/poetry.lock
@@ -772,8 +772,8 @@ pydantic = "==1.10.*"
 [package.source]
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
-reference = "HEAD"
-resolved_reference = "4efa978094b6a125532b764ca0ba27103095c4b7"
+reference = "ARXIVCE-2614-RemoteConverterDriver"
+resolved_reference = "3353f4a21e53ca8bda21e29cdb4a5b418c5d7075"
 subdirectory = "preflight_parser"
 
 [[package]]
@@ -1153,8 +1153,8 @@ toml = "^0.10.2"
 [package.source]
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
-reference = "HEAD"
-resolved_reference = "4efa978094b6a125532b764ca0ba27103095c4b7"
+reference = "ARXIVCE-2614-RemoteConverterDriver"
+resolved_reference = "3353f4a21e53ca8bda21e29cdb4a5b418c5d7075"
 subdirectory = "tex_inspection"
 
 [[package]]
@@ -1359,7 +1359,7 @@ files = []
 develop = false
 
 [package.dependencies]
-preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "preflight_parser"}
+preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", branch = "ARXIVCE-2614-RemoteConverterDriver", subdirectory = "preflight_parser"}
 ruamel-yaml = "^0.18.5"
 toml = "^0.10.2"
 tomli_w = "^1.0"
@@ -1367,11 +1367,11 @@ tomli_w = "^1.0"
 [package.source]
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
-reference = "HEAD"
-resolved_reference = "4efa978094b6a125532b764ca0ba27103095c4b7"
+reference = "ARXIVCE-2614-RemoteConverterDriver"
+resolved_reference = "3353f4a21e53ca8bda21e29cdb4a5b418c5d7075"
 subdirectory = "zerozeroreadme"
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "8654f6602bc896c175fbf7d94828b2210804256c32baac483ec17a1266b0cf08"
+content-hash = "b4ac93154a443f0d5ac66e5b923098afbce15b63a18258187f770d8c28c2a90f"

--- a/tex2pdf_service/pyproject.toml
+++ b/tex2pdf_service/pyproject.toml
@@ -17,9 +17,9 @@ ruamel-yaml = "^0.18.5"
 pillow = "^10.4.0"
 python-multipart = "^0.0.6"
 psutil = "^5.9.8"
-tex_inspection = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "tex_inspection", branch = "ARXIVCE-2542-use-new-preflight" }
-preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "preflight_parser", branch = "ARXIVCE-2542-use-new-preflight" }
-zerozeroreadme = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "zerozeroreadme", branch = "ARXIVCE-2542-use-new-preflight" }
+tex_inspection = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "tex_inspection" }
+preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "preflight_parser" }
+zerozeroreadme = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "zerozeroreadme" }
 hypercorn = {extras = ["h2"], version = "^0.16.0"}
 pymupdf = "^1.24.10"
 requests = "^2.32.0"

--- a/tex2pdf_service/pyproject.toml
+++ b/tex2pdf_service/pyproject.toml
@@ -17,9 +17,9 @@ ruamel-yaml = "^0.18.5"
 pillow = "^10.4.0"
 python-multipart = "^0.0.6"
 psutil = "^5.9.8"
-tex_inspection = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "tex_inspection" }
-preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "preflight_parser" }
-zerozeroreadme = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "zerozeroreadme" }
+tex_inspection = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "tex_inspection", branch = "ARXIVCE-2614-RemoteConverterDriver" }
+preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "preflight_parser", branch = "ARXIVCE-2614-RemoteConverterDriver" }
+zerozeroreadme = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "zerozeroreadme", branch = "ARXIVCE-2614-RemoteConverterDriver" }
 hypercorn = {extras = ["h2"], version = "^0.16.0"}
 pymupdf = "^1.24.10"
 requests = "^2.32.0"

--- a/tex2pdf_service/pyproject.toml
+++ b/tex2pdf_service/pyproject.toml
@@ -22,6 +22,7 @@ preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdi
 zerozeroreadme = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "zerozeroreadme", branch = "ARXIVCE-2542-use-new-preflight" }
 hypercorn = {extras = ["h2"], version = "^0.16.0"}
 pymupdf = "^1.24.10"
+requests = "^2.32.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"
@@ -31,7 +32,6 @@ mypy = "*"
 mypy-extensions = "*"
 tqdm = "^4.66.2"
 uvicorn = "^0.29.0"
-requests = "^2.32.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tex2pdf_service/tests/conftest.py
+++ b/tex2pdf_service/tests/conftest.py
@@ -1,5 +1,6 @@
 
 def pytest_addoption(parser):
+    parser.addoption("--keep-docker-running", action="store_true", help="keep docker image running")
     parser.addoption("--no-docker-setup", action="store_true", help="do not run docker setup, expect a running docker")
     parser.addoption("--docker-port", action="store", default="33031", help="outside docker port to use")
 

--- a/tex2pdf_service/tests/test_docker.py
+++ b/tex2pdf_service/tests/test_docker.py
@@ -184,14 +184,16 @@ def test_remote2023(docker_container) -> None:
     tarball = os.path.join(os.getcwd(), "tests", "fixture", "tarballs", "test1", "test1.tar.gz")
     out_dir = os.path.join(os.getcwd(), "tests", "test-output", "test1-remote")
     url = docker_container + "/convert/"
+    tag = os.path.basename(tarball)
 
     logging.debug("Before instantiating the RemoteConverterDriver")
 
     shutil.rmtree(out_dir, ignore_errors=True)
 
     converter = RemoteConverterDriver(url, 600, out_dir, tarball,
-                                      use_addon_tree=False,
+                                      use_addon_tree=False, tag=tag,
                                       auto_detect=True)
     logging.debug("Calling generate_pdf")
     pdf = converter.generate_pdf()
+    assert os.path.isfile(f"{out_dir}/{tag}-outcome.tar.gz")
     assert pdf == "test1.pdf"

--- a/tex2pdf_service/tests/test_docker.py
+++ b/tex2pdf_service/tests/test_docker.py
@@ -101,7 +101,7 @@ def docker_container(request):
 
     yield url
 
-    if not request.config.getoption('--no-docker-setup'):
+    if not request.config.getoption('--no-docker-setup') and not request.config.getoption('--keep-docker-running'):
         # Stop the container after tests
         with open("tex2pdf.log", "w", encoding="utf-8") as log:
             subprocess.call(["docker", "logs", container_name], stdout=log, stderr=log)
@@ -195,5 +195,6 @@ def test_remote2023(docker_container) -> None:
                                       auto_detect=True)
     logging.debug("Calling generate_pdf")
     pdf = converter.generate_pdf()
-    assert os.path.isfile(f"{out_dir}/{tag}-outcome.tar.gz")
+    assert os.path.isfile(f"{out_dir}/outcome-test1.json")
+    assert os.path.isfile(f"{out_dir}/out/test1.pdf")
     assert pdf == "test1.pdf"

--- a/tex2pdf_service/tests/test_docker.py
+++ b/tex2pdf_service/tests/test_docker.py
@@ -5,7 +5,7 @@ import requests
 import subprocess
 import urllib.parse
 import pytest
-from bin.compile_submissions import get_outcome_meta
+from bin.compile_submissions import get_outcome_meta_and_files_info
 import logging
 import json
 
@@ -36,7 +36,7 @@ def submit_tarball(service: str, tarball: str, outcome_file: str, tex2pdf_timeou
                         else:
                             with open(outcome_file, "wb") as out:
                                 out.write(res.content)
-                            meta, lines, clsfiles, styfiles, pdfchecksum = get_outcome_meta(outcome_file)
+                            meta, lines, clsfiles, styfiles, pdfchecksum = get_outcome_meta_and_files_info(outcome_file)
                 else:
                     logging.warning(f"%s: status code %d", url, status_code)
 

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -571,11 +571,13 @@ class RemoteConverterDriver(ConverterDriver):
         self.t0 = time.perf_counter()
 
         local_tarball = os.path.join(self.work_dir, self.source)
-        outcome_file = os.path.join(self.work_dir, f"outcome-{self.source}")
+        outcome_file = os.path.join(self.work_dir, "outcome.tar.gz")
 
         # hard coded post_timeout = 600 as of now
         # not sure I want to make this another init option
-        submit_tarball(self.service, local_tarball, outcome_file, int(self.max_time_budget), self.post_timeout)
+        logger.debug("Submitting %s to %s with output to %s", local_tarball, self.service, outcome_file)
+        submit_tarball(self.service, local_tarball, outcome_file, int(self.max_time_budget), self.post_timeout, self.auto_detect)
+        logger.debug("Returned from posting")
         self.outcome = get_outcome_meta(outcome_file)
 
         # TODO

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -581,7 +581,7 @@ class RemoteConverterDriver(ConverterDriver):
 
         if not success:
             logger.warning("Couldn't generate PDF")
-            return
+            return None
 
         # unpack the tarball for further processing
         logger.debug("Unpacking to workdir %s", self.work_dir)

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -577,7 +577,11 @@ class RemoteConverterDriver(ConverterDriver):
         outcome_file = os.path.join(self.work_dir, f"{tag}-outcome.tar.gz")
 
         logger.debug("Submitting %s to %s with output to %s", local_tarball, self.service, outcome_file)
-        submit_tarball(self.service, local_tarball, outcome_file, int(self.max_time_budget), self.post_timeout, self.auto_detect)
+        success = submit_tarball(self.service, local_tarball, outcome_file, int(self.max_time_budget), self.post_timeout, self.auto_detect)
+
+        if not success:
+            logger.warning("Couldn't generate PDF")
+            return
 
         # unpack the tarball for further processing
         logger.debug("Unpacking to workdir %s", self.work_dir)

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -581,6 +581,8 @@ class RemoteConverterDriver(ConverterDriver):
 
         if not success:
             logger.warning("Couldn't generate PDF")
+            # ensure we have a zzrm file!
+            self.zzrm = ZeroZeroReadMe()
             return None
 
         # unpack the tarball for further processing

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -560,7 +560,7 @@ class RemoteConverterDriver(ConverterDriver):
     service: str
     post_timeout: int
 
-    def __init__(self, service: str, post_timeout: int, work_dir: str, source: str, **kwargs):
+    def __init__(self, service: str, post_timeout: int, work_dir: str, source: str, **kwargs: typing.Any):
         super().__init__(work_dir, source, **kwargs)
         self.service = service
         self.post_timeout = post_timeout

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -24,7 +24,7 @@ from tex2pdf import (
 )
 from tex2pdf.doc_converter import combine_documents, strip_to_basename
 from tex2pdf.pdf_watermark import Watermark, add_watermark_text_to_pdf
-from tex2pdf.remote_call import submit_tarball, get_outcome_meta
+from tex2pdf.remote_call import service_process_tarball, get_outcome_meta
 from tex2pdf.service_logger import get_logger
 from tex2pdf.tarball import ZZRMUnsupportedCompiler, ZZRMUnderspecified, chmod_775, unpack_tarball
 from tex2pdf.tex_patching import fix_tex_sources
@@ -577,7 +577,7 @@ class RemoteConverterDriver(ConverterDriver):
         outcome_file = os.path.join(self.work_dir, f"{tag}-outcome.tar.gz")
 
         logger.debug("Submitting %s to %s with output to %s", local_tarball, self.service, outcome_file)
-        success = submit_tarball(self.service, local_tarball, outcome_file, int(self.max_time_budget), self.post_timeout, self.auto_detect)
+        success = service_process_tarball(self.service, local_tarball, outcome_file, int(self.max_time_budget), self.post_timeout, self.auto_detect)
 
         if not success:
             logger.warning("Couldn't generate PDF")

--- a/tex2pdf_service/tex2pdf/converter_driver.py
+++ b/tex2pdf_service/tex2pdf/converter_driver.py
@@ -570,16 +570,14 @@ class RemoteConverterDriver(ConverterDriver):
         logger = get_logger()
         self.t0 = time.perf_counter()
 
-        local_tarball = os.path.join(self.work_dir, self.source)
-        outcome_file = os.path.join(self.work_dir, "outcome.tar.gz")
+        tag = self.tag or os.path.basename(self.source)
 
-        # hard coded post_timeout = 600 as of now
-        # not sure I want to make this another init option
+        local_tarball = os.path.join(self.work_dir, self.source)
+        outcome_file = os.path.join(self.work_dir, f"{tag}-outcome.tar.gz")
+
         logger.debug("Submitting %s to %s with output to %s", local_tarball, self.service, outcome_file)
         submit_tarball(self.service, local_tarball, outcome_file, int(self.max_time_budget), self.post_timeout, self.auto_detect)
         logger.debug("Returned from posting")
         self.outcome = get_outcome_meta(outcome_file)
 
-        # TODO
-        # - discard (is this necessary?) the stuff we have created
         return self.outcome.get("pdf_file")

--- a/tex2pdf_service/tex2pdf/remote_call.py
+++ b/tex2pdf_service/tex2pdf/remote_call.py
@@ -1,0 +1,70 @@
+"""Compile a tarball via the service URL to an outcome file."""
+
+import json
+import logging
+import os
+import tarfile
+import time
+
+import requests
+
+
+def get_outcome_meta(outcome_file: str) -> dict:
+    """Open a compressed outcome tar archive and get the metadata."""
+    meta = {}
+    with tarfile.open(outcome_file, "r:gz") as outcome:
+        for name in outcome.getnames():
+            if name.startswith("outcome-") and name.endswith(".json"):
+                meta_contents = outcome.extractfile(name)
+                if meta_contents:
+                    meta.update(json.load(meta_contents))
+
+    return meta
+
+
+def submit_tarball(service: str, tarball: str, outcome_file: str, tex2pdf_timeout: int, post_timeout: int) -> bool:
+    """Submit tarball to compilation service."""
+    if os.path.exists(outcome_file):
+        raise FileExistsError(f"Outcome file {outcome_file} already exists!")
+    os.makedirs(os.path.dirname(outcome_file), exist_ok=True)
+    logging.info("File: %s", os.path.basename(tarball))
+    meta = {}
+    status_code = None
+
+    with open(tarball, "rb") as data_fd:
+        uploading = {"incoming": (os.path.basename(tarball), data_fd, "application/gzip")}
+        while True:
+            try:
+                res = requests.post(
+                    service + f"?timeout={tex2pdf_timeout}",
+                    files=uploading,
+                    timeout=post_timeout,
+                    allow_redirects=False,
+                )
+                status_code = res.status_code
+                if status_code == 504:
+                    logging.warning("Got 504 for %s", service)
+                    time.sleep(1)
+                    continue
+
+                if status_code == 200:
+                    if res.content:
+                        with open(outcome_file, "wb") as out:
+                            out.write(res.content)
+                        meta, lines, clsfiles, styfiles, pdfchecksum = get_outcome_meta(outcome_file)
+            except TimeoutError:
+                logging.warning("%s: Connection timed out", tarball)
+
+            except Exception as exc:
+                logging.warning("%s: %s", tarball, str(exc))
+            break
+
+    success = meta.get("status") == "success"
+    logging.log(
+        logging.INFO if success else logging.WARNING,
+        "submit: %s (%s) %s",
+        os.path.basename(tarball),
+        str(status_code),
+        success,
+    )
+    return success

--- a/tex2pdf_service/tex2pdf/remote_call.py
+++ b/tex2pdf_service/tex2pdf/remote_call.py
@@ -32,7 +32,8 @@ def service_process_tarball(service: str, tarball: str, outcome_file: str, tex2p
 
     with open(tarball, "rb") as data_fd:
         uploading = {"incoming": (os.path.basename(tarball), data_fd, "application/gzip")}
-        while True:
+        retries = 2
+        for attempt in range(1+retries):
             try:
                 post_url = service + f"?timeout={tex2pdf_timeout}&auto_detect={auto_detect}"
                 logging.debug("POST URL: %s", post_url)
@@ -45,6 +46,7 @@ def service_process_tarball(service: str, tarball: str, outcome_file: str, tex2p
                 )
                 status_code = res.status_code
                 if status_code == 504:
+                    # This is the only place we retry, and at most 3 times in total.
                     logging.warning("Got 504 for %s", service)
                     time.sleep(1)
                     continue

--- a/tex2pdf_service/tex2pdf/remote_call.py
+++ b/tex2pdf_service/tex2pdf/remote_call.py
@@ -21,8 +21,8 @@ def get_outcome_meta(outcome_file: str) -> dict:
     return meta
 
 
-def submit_tarball(service: str, tarball: str, outcome_file: str, tex2pdf_timeout: int, post_timeout: int, auto_detect: bool = False) -> bool:
-    """Submit tarball to compilation service."""
+def service_process_tarball(service: str, tarball: str, outcome_file: str, tex2pdf_timeout: int, post_timeout: int, auto_detect: bool = False) -> bool:
+    """Submit tarball to compilation service and receive result."""
     if os.path.exists(outcome_file):
         raise FileExistsError(f"Outcome file {outcome_file} already exists!")
     os.makedirs(os.path.dirname(outcome_file), exist_ok=True)

--- a/zerozeroreadme/poetry.lock
+++ b/zerozeroreadme/poetry.lock
@@ -133,7 +133,7 @@ pydantic = "==1.10.*"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "ARXIVCE-2614-RemoteConverterDriver"
-resolved_reference = "f479ab790e83c6643bc8adc9aa98b0d5cc241e3d"
+resolved_reference = "2c29e6352d0408ee78b2e7920e2e306acf3d8506"
 subdirectory = "preflight_parser"
 
 [[package]]

--- a/zerozeroreadme/poetry.lock
+++ b/zerozeroreadme/poetry.lock
@@ -132,8 +132,8 @@ pydantic = "==1.10.*"
 [package.source]
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
-reference = "HEAD"
-resolved_reference = "e665aed7daa77794115fee23e306c5e148e2dcf2"
+reference = "ARXIVCE-2614-RemoteConverterDriver"
+resolved_reference = "f479ab790e83c6643bc8adc9aa98b0d5cc241e3d"
 subdirectory = "preflight_parser"
 
 [[package]]
@@ -339,4 +339,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "87b09e9e362d1a6f0796a73b18ede4904b9106ebfb50ac9fcac2439dac6d1785"
+content-hash = "ff8c9af9d493d4c229e701571d2019754d064280f56c1d1d358d4ebb10adbba7"

--- a/zerozeroreadme/poetry.lock
+++ b/zerozeroreadme/poetry.lock
@@ -133,7 +133,7 @@ pydantic = "==1.10.*"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "ARXIVCE-2614-RemoteConverterDriver"
-resolved_reference = "2c29e6352d0408ee78b2e7920e2e306acf3d8506"
+resolved_reference = "e32ced058688a5fd7f9f84f06a4488f9ab65893d"
 subdirectory = "preflight_parser"
 
 [[package]]

--- a/zerozeroreadme/pyproject.toml
+++ b/zerozeroreadme/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.11"
 ruamel-yaml = "^0.18.5"
 toml = "^0.10.2"
 tomli_w = "^1.0"
-preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "preflight_parser" }
+preflight_parser = {git = "https://github.com/arXiv/submission-tools.git", subdirectory = "preflight_parser", branch = "ARXIVCE-2614-RemoteConverterDriver" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
- factor out remote submission functionality from `compile_submissions` into
  a new module `remote_call`
- use the `remote_call` in `compile_submissions` script
- generate a RemoteConverterDriver based on ConverterDriver with overriden `generate_pdf`
  resuing the `remote_call` facilities