### PR TITLE
Preflight fix toplevel misdetection

### DIFF
--- a/preflight_parser/preflight_parser/__init__.py
+++ b/preflight_parser/preflight_parser/__init__.py
@@ -302,6 +302,8 @@ class ParsedTeXFile(BaseModel):
     language: LanguageType = LanguageType.unknown
     engine: EngineType = EngineType.unknown
     postprocess: PostProcessType = PostProcessType.unknown
+    contains_documentclass: bool = False
+    contains_bye: bool = False
     used_tex_files: list[str] = []
     used_bib_files: list[str] = []
     used_other_files: list[str] = []
@@ -322,9 +324,11 @@ class ParsedTeXFile(BaseModel):
             language = LanguageType.latex
         if re.search(r"\\text(bf|it|sl)|\\section|\\chapter", self._data, re.MULTILINE):
             language = LanguageType.latex
-        if re.search(r"^[^%\n]*\\bye[^a-zA-Z0-9_\n]", self._data, re.MULTILINE):
+        if re.search(r"^[^%\n]*\\bye[^a-zA-Z0-9_]", self._data, re.MULTILINE):
             language = LanguageType.tex
-        if re.search(r"^[^%\n]*\\documentclass", self._data, re.MULTILINE):
+            self.contains_bye = True
+        if re.search(r"^[^%\n]*\\documentclass[^a-zA-Z0-9_]", self._data, re.MULTILINE):
+            self.contains_documentclass = True
             if language == LanguageType.tex:
                 self.issues.append(
                     TeXFileIssue(IssueType.conflicting_file_type, "containing both bye and documentclass")
@@ -510,8 +514,35 @@ class ParsedTeXFile(BaseModel):
         logging.debug(file_incspec)
         self.mentioned_files |= file_incspec
 
+    def generic_walk_document_tree(
+        self, map: Callable[["ParsedTeXFile"], typing.Any], reduce: Callable[[typing.Any, typing.Any], typing.Any]
+    ):
+        """Walk the document tree in map/reduce fashion."""
+        return self._generic_walk_document_tree(map, reduce, {})
+
+    def _generic_walk_document_tree(
+        self,
+        map: Callable[["ParsedTeXFile"], typing.Any],
+        reduce: Callable[[typing.Any, typing.Any], typing.Any],
+        visited: dict[str, bool],
+    ) -> list[typing.Any]:
+        """Call a function on any node of a document tree - internal helper."""
+        ret = map(self)
+        visited[self.filename] = True
+        for n in self.children:
+            if n.filename not in visited:
+                ret_kid = n._generic_walk_document_tree(map, reduce, visited)
+                ret = reduce(ret, ret_kid)
+        return ret
+
+    # TODO rewrite using _generic_walk_document_tree - below code breaks with
     def walk_document_tree(self, func: Callable[["ParsedTeXFile"], list[typing.Any]]) -> list[typing.Any]:
         """Call a function on any node of a document tree."""
+        # return self._generic_walk_document_tree(
+        #     func,
+        #     lambda x,y: x.extend(y),
+        #     {}
+        # )
         return self._walk_document_tree(func, {})
 
     def _walk_document_tree(
@@ -526,6 +557,7 @@ class ParsedTeXFile(BaseModel):
                 ret.extend(ret_kid)
         return ret
 
+    # TODO rewrite using _generic_walk_document_tree
     def find_entry_in_subgraph(
         self,
     ) -> tuple[LanguageType, OutputType, EngineType, PostProcessType, list[TeXFileIssue]]:
@@ -605,6 +637,7 @@ class ParsedTeXFile(BaseModel):
 
         return found_language, found_output, found_engine, found_postprocess, issues
 
+    # TODO rewrite using _generic_walk_document_tree
     def recursive_collect_files(self, what: FileType | str) -> list[str]:
         """Recursively collect all tex/bib/other files."""
         return self._recursive_collect_files(what, {})
@@ -1045,7 +1078,22 @@ def compute_toplevel_files(roots: dict[str, ParsedTeXFile], nodes: dict[str, Par
             if nr_issues > 0:
                 issues.append(TeXFileIssue(IssueType.issue_in_subfile, str(nr_issues), filename=fn))
         tl.issues = issues
-        toplevel_files[f] = tl
+        # it is not enough to be a latex file and a root file to be a toplevel file
+        # we need to have documentclass being found in one of the include files
+        if tl_n.language == LanguageType.latex:
+            contains_documentclass_somewhere = tl_n.generic_walk_document_tree(
+                lambda x: x.contains_documentclass, lambda x, y: x or y
+            )
+            #
+            if contains_documentclass_somewhere:
+                toplevel_files[f] = tl
+        elif tl_n.language == LanguageType.tex or tl_n.language == LanguageType.unknown:
+            # we could have \bye in a subfile, and the main file is not detected as tex file
+            contains_bye_somewhere = tl_n.generic_walk_document_tree(lambda x: x.contains_bye, lambda x, y: x or y)
+            if contains_bye_somewhere:
+                toplevel_files[f] = tl
+        else:
+            raise PreflightException(f"Unsupported language type {tl_n.language}")
 
     return toplevel_files
 

--- a/preflight_parser/tests/fixture/multi_tex_3/main.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/main.tex
@@ -1,0 +1,21 @@
+\documentclass{article}
+\usepackage{lipsum} % for generating dummy text
+
+\title{A Simple LaTeX Article}
+\author{David Fielding}
+\date{\today}
+
+\begin{document}
+
+\maketitle
+
+\section{Introduction}
+\lipsum[1] % Generates a paragraph of dummy text
+
+\section{Main Body}
+\lipsum[2-4] % Generates more dummy text
+
+\section{Conclusion}
+\lipsum[5] % Generates another paragraph of dummy text
+
+\end{document}

--- a/preflight_parser/tests/fixture/multi_tex_3/ms.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/ms.tex
@@ -1,0 +1,23 @@
+\documentclass{article}
+\usepackage{lipsum} % for generating dummy text
+
+\title{A Simple LaTeX Article}
+\author{David Fielding}
+\date{\today}
+
+\begin{document}
+
+\maketitle
+
+\section{Introduction}
+\lipsum[1] % Generates a paragraph of dummy text
+
+\section{Main Body}
+\lipsum[2-4] % Generates more dummy text
+
+\include{mssection}
+
+\section{Conclusion}
+\lipsum[5] % Generates another paragraph of dummy text
+
+\end{document}

--- a/preflight_parser/tests/fixture/multi_tex_3/mssection.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/mssection.tex
@@ -1,0 +1,4 @@
+\section{MS Section One}
+This is the content of the ms.tex section. It includes some example text.
+
+\lipsum[1] % Generates a paragraph of dummy text

--- a/preflight_parser/tests/fixture/multi_tex_3/mssection2.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/mssection2.tex
@@ -1,0 +1,5 @@
+\section{Section Two}
+This section is not included, and should de detected as extraneous or
+unused.
+
+\lipsum[1] % Generates a paragraph of dummy text

--- a/preflight_parser/tests/fixture/multi_tex_3/newmain.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/newmain.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+
+% Include external files
+\begin{document}
+
+\tableofcontents
+
+\section{Introduction}
+This is the introduction to the document.
+
+\include{section1}
+\include{section2}
+
+\end{document}

--- a/preflight_parser/tests/fixture/multi_tex_3/plain-main.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/plain-main.tex
@@ -1,0 +1,9 @@
+
+Hello World
+
+This is a plain tex document
+
+\input plainsection1
+\input plainsection2
+\input plainclosing
+

--- a/preflight_parser/tests/fixture/multi_tex_3/plainclosing.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/plainclosing.tex
@@ -1,0 +1,5 @@
+
+End of the plain test file
+
+\bye
+

--- a/preflight_parser/tests/fixture/multi_tex_3/plainsection1.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/plainsection1.tex
@@ -1,0 +1,3 @@
+
+Section 1 of plain-main.tex
+

--- a/preflight_parser/tests/fixture/multi_tex_3/plainsection2.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/plainsection2.tex
@@ -1,0 +1,2 @@
+
+Section 2 of plain-main

--- a/preflight_parser/tests/fixture/multi_tex_3/plainsection3.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/plainsection3.tex
@@ -1,0 +1,3 @@
+
+Unused plain tex section
+

--- a/preflight_parser/tests/fixture/multi_tex_3/section1.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/section1.tex
@@ -1,0 +1,4 @@
+\section{Section One}
+This is the content of the first section. It includes some example text.
+
+\lipsum[1] % Generates a paragraph of dummy text

--- a/preflight_parser/tests/fixture/multi_tex_3/section2.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/section2.tex
@@ -1,0 +1,4 @@
+\section{Section Two}
+This is the content of the second section. It includes some example text.
+
+\lipsum[1] % Generates a paragraph of dummy text

--- a/preflight_parser/tests/fixture/multi_tex_3/section3.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/section3.tex
@@ -1,0 +1,5 @@
+\section{Section Three}
+This section is not included, and should de detected as extraneous or
+unused.
+
+\lipsum[1] % Generates a paragraph of dummy text

--- a/preflight_parser/tests/fixture/multi_tex_3/supplement one.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/supplement one.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{lipsum} % for generating dummy text
+
+\begin{document}
+
+\section*{Supplement 1}
+\lipsum[1-3] % Generates dummy text for the supplement
+
+\end{document}

--- a/preflight_parser/tests/fixture/multi_tex_3/supplement two.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/supplement two.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{lipsum} % for generating dummy text
+
+\begin{document}
+
+\section*{Supplement 2}
+\lipsum[1-3] % Generates dummy text for the supplement
+
+\end{document}

--- a/preflight_parser/tests/fixture/multi_tex_3/supplement1.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/supplement1.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{lipsum} % for generating dummy text
+
+\begin{document}
+
+\section*{Supplement 1}
+\lipsum[1-3] % Generates dummy text for the supplement
+
+\end{document}

--- a/preflight_parser/tests/fixture/multi_tex_3/supplement2.tex
+++ b/preflight_parser/tests/fixture/multi_tex_3/supplement2.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{lipsum} % for generating dummy text
+
+\begin{document}
+
+\section*{Supplement 2}
+\lipsum[1-3] % Generates dummy text for the supplement
+
+\end{document}


### PR DESCRIPTION
We missed to check for presence of documentclass/bye somewhere in the documenttree, fix that.
Add unit-tests.