### PR TITLE
Fix ancillary file removal logic

### DIFF
--- a/tex2pdf-service/tests/test_docker.py
+++ b/tex2pdf-service/tests/test_docker.py
@@ -198,6 +198,17 @@ def test_api_test_anc_ignore(docker_container):
     assert meta is not None
     assert meta.get("status") == "fail"
 
+@pytest.mark.integration
+def test_api_test_anc_ignore_no_ancfiles(docker_container):
+    url = docker_container + "/convert"
+    tarball = os.path.join(SELF_DIR, "fixture/tarballs/test4/test4.tar.gz")
+    outcome = os.path.join(SELF_DIR, "output/test4.outcome.tar.gz")
+    meta = submit_tarball(url, tarball, outcome, api_args={"auto_detect": "true", "hide_anc_dir": "true"})
+    assert meta is not None
+    assert meta.get("pdf_file") == "test4.pdf"
+    assert meta.get("tex_files") == ["main.tex", "gdp.tex"]
+    assert len(meta.get("converters", [])) == 2
+    assert len(meta["converters"][0]["runs"]) == 4  # latex, latex, dvi2ps, ps2pdf
 
 @pytest.mark.integration
 def test_api_preflight(docker_container):

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -133,7 +133,7 @@ class ConverterDriver:
         """The converter driver log."""
         return "\n".join(self.converter_logs) if self.converter_logs else self.note
 
-    def _find_anc_rename_directory(self, ancdir: str) -> tuple[str,str] | None:
+    def _find_anc_rename_directory(self, ancdir: str) -> str | None:
         target: str|None = None
         if os.path.isdir(ancdir):
             target = f"{self.in_dir}/_anc"

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -225,8 +225,9 @@ class ConverterDriver:
             # Deal with ignoring of anc directory, if requested
             if self.hide_anc_dir:
                 ancdir = f"{self.in_dir}/anc"
-                target: str|None = f"{self.in_dir}/_anc"
+                target: str|None = None
                 if os.path.isdir(ancdir):
+                    target = f"{self.in_dir}/_anc"
                     assert target is not None  # placate stupid mypy
                     if os.path.isdir(target):
                         # we need to find a way to rename it

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -133,8 +133,7 @@ class ConverterDriver:
         """The converter driver log."""
         return "\n".join(self.converter_logs) if self.converter_logs else self.note
 
-    def _find_anc_rename_directory(self) -> str | None:
-        ancdir = f"{self.in_dir}/anc"
+    def _find_anc_rename_directory(self, ancdir: str) -> tuple[str,str] | None:
         target: str|None = None
         if os.path.isdir(ancdir):
             target = f"{self.in_dir}/_anc"
@@ -250,7 +249,7 @@ class ConverterDriver:
             # Deal with ignoring of anc directory, if requested
             if self.hide_anc_dir:
                 ancdir = f"{self.in_dir}/anc"
-                target: str|None = self._find_anc_rename_directory()
+                target: str|None = self._find_anc_rename_directory(ancdir)
                 # we should have a target now that works
                 if target is None:
                     logger.warning("Cannot find target to rename anc directory, strange!")


### PR DESCRIPTION
we tried to restore the _anc directory to anc in case there were no anc directory in the first place, not good.
Also factor out the renaming target search logic, and ensured that the backup is renamed back to anc even in case of exceptions in the tex compilation code.
