### PR TITLE
Ensure that we pass only single lines to kpse_find_files

### DIFF
--- a/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
@@ -549,7 +549,15 @@ class ParsedTeXFile(BaseModel):
                 raise PreflightException(f"Unexpected type of file_argument: {type(incdef.file_argument)}")
 
         logging.debug(file_incspec)
-        self.mentioned_files |= file_incspec
+        # clean up the actual file argument
+        # the filearg could be very strange stuff, like when \includegraphics is redefined
+        # \def\includegraphics{....}
+        # in the case of agutexSI2019.cls, the .... even includes a \n
+        file_incspec_cleaned: dict[str, IncludeSpec] = {}
+        for k, v in file_incspec.items():
+            k_cleaned = k.encode("unicode_escape").decode("utf-8")
+        file_incspec_cleaned[k_cleaned] = v
+        self.mentioned_files |= file_incspec_cleaned
 
     def generic_walk_document_tree(self, map: Callable[["ParsedTeXFile"], T], reduce: Callable[[T, T], T]) -> T:
         """Walk the document tree in map/reduce fashion."""


### PR DESCRIPTION
In some instances, the file name argument of in include command like \includegraphics can stretch multiple lines. One example is a redefinition of \includegraphics:
	\def\includegraphics{some text with newlines}
We don't detect those as redefinitions, so try to search for
	"some text with newlines"
which is printed to stdout to be passed on to the lua script.

Make sure we escape those characters so that everything remains on a single line.

This is in line with the arXiv requirement that filenames don't contain strange characters (not even space, although that is not a problem), but definitely does not contain newlines (which is from the standard a valid part of a filename!)