### PR TITLE
[ARXIVCE-3236] ZZRM: do *not* default to set compiler to pdflatex

### DIFF
--- a/tex2pdf-tools/tests/zerozeroreadme/test_zzrm.py
+++ b/tex2pdf-tools/tests/zerozeroreadme/test_zzrm.py
@@ -101,7 +101,6 @@ class Test00README(unittest.TestCase):
         sio.seek(0)
         data = sio.read()
         expected = """process:
-  compiler: pdflatex
   fontmaps:
   - myfonts1.map
   - myfonts2.map
@@ -137,7 +136,6 @@ stamp: false
 stamp = false
 
 [process]
-compiler = "pdflatex"
 fontmaps = [
     "myfonts1.map",
     "myfonts2.map",
@@ -151,7 +149,6 @@ fontmaps = [
         data = zzrm.to_json()
         expected = """{
     "process": {
-        "compiler": "pdflatex",
         "fontmaps": [
             "myfonts1.map",
             "myfonts2.map"

--- a/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
@@ -132,7 +132,7 @@ class ZeroZeroReadMe:
         self.version: int = version  # classic 00README.XXX is v1, dict i/o is v2.
         self.readme_filename: str | None = None
         self.readme: list[str] | None = None
-        self.process: MainProcessSpec = MainProcessSpec(compiler="pdflatex")
+        self.process: MainProcessSpec = MainProcessSpec()
         self.sources: OrderedDict[str, UserFile] = OrderedDict()
         self.stamp: bool | None = True
         self.nohyperref: bool | None = None
@@ -414,7 +414,10 @@ class ZeroZeroReadMe:
         # If no compiler is selected, select it based on the first toplevel file
         if self.process.compiler is None:
             self.process.compiler = CompilerSpec(
-                engine=EngineType.unknown, lang=LanguageType.unknown, output=OutputType.unknown
+                engine=EngineType.unknown,
+                lang=LanguageType.unknown,
+                output=OutputType.unknown,
+                postp=PostProcessType.unknown,
             )
         if not self.process.compiler.is_determined:
             first_tex = self.toplevels[0]


### PR DESCRIPTION
This was originally done before the introduction of preflight to default to pdflatex as compiler.
But since we are nowadays using zzrm and update it from preflight, the default "pdflatex" compiler would never be overwritten, and so all submissions without a ZZRM would be pdflatex, even if preflight correctly determines that we need to use "latex_dvips_ps2pdf".

Changes in this PR:
- drop the default value for compiler
- fix a missing argument to the initializer
- adjust unit tests to have empty compilers for the tests