### PR TITLE
[ARXIVCE-3242] fix detection of commands at end of file

### DIFF
--- a/tex2pdf-tools/tests/preflight/fixture/last-line-no-newline/foo.tex
+++ b/tex2pdf-tools/tests/preflight/fixture/last-line-no-newline/foo.tex
@@ -1,0 +1,2 @@
+Hello World
+\include{bla}

--- a/tex2pdf-tools/tests/preflight/fixture/last-line-no-newline/main.tex
+++ b/tex2pdf-tools/tests/preflight/fixture/last-line-no-newline/main.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+\input foo
+\end{document}

--- a/tex2pdf-tools/tests/preflight/test_preflight.py
+++ b/tex2pdf-tools/tests/preflight/test_preflight.py
@@ -263,3 +263,17 @@ class TestPreflight(unittest.TestCase):
             pf.detected_toplevel_files[0].issues[0].key,
             "unsupported_compiler_type"
         )
+
+    def test_no_final_newline(self):
+        """Test whether detection of include command works with no final newline."""
+        dir_path = os.path.join(self.fixture_dir, "last-line-no-newline")
+        pf: PreflightResponse = generate_preflight_response(dir_path)
+        self.assertEqual(pf.status.key.value, "success")
+        self.assertEqual(len(pf.detected_toplevel_files), 1)
+        self.assertEqual(pf.detected_toplevel_files[0].filename, "main.tex")
+        found_foo_tex = False
+        for tf in pf.tex_files:
+            if tf.filename == "foo.tex":
+                found_foo_tex = True
+                self.assertEqual(tf.used_tex_files, ["bla.tex"])
+        self.assertTrue(found_foo_tex)

--- a/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
@@ -880,7 +880,7 @@ ARGS_INCLUDE_REGEX = r"""
     \s*({[^}]*})?\s*(?:%.*\n)?        # actual argument with braces
     \s*({[^}]*})?\s*(?:%.*\n)?        # second argument with braces
     \s*({[^}]*})?                     # third argument with braces
-    (?=\s*\W)                         # any non-word character terminating the command
+    (?=\s*(\W|$))                         # any non-word character terminating the command
 """
 
 # All possible CompilerSpecs


### PR DESCRIPTION
There need not be a character whatsoever after a command if it is the end of the file.