### PR TITLE
[Directives] consistently use all-caps 00README to minimize confusion

### DIFF
--- a/tex2pdf-tools/README.md
+++ b/tex2pdf-tools/README.md
@@ -1,7 +1,7 @@
 # submission-tools
 
 arXiv submission related tool repository, mainly collection `tex2pdf` with
-its subpackages (`preflight`, `zerozeroreadme`, `tex_inspection`, and `service`)
+its subpackages (`preflight`, `zerozeroreadme`, `tex_inspection`, `directives`)
 and the `pdf_profile` package.
 
 # PDF Profile
@@ -26,10 +26,8 @@ Package: `tex2pdf.zerozeroreadme`
 
 Full specification: [00README for authors](https://docs.google.com/document/d/1WbAh2atcDLG0-yJEP9WDKqujHtwH1Kp_TojykeC2HFQ/edit?usp=sharing)
 
-# TeX2PDF Service
+# Directives
 
-Package: `tex2pdf.service`
+Package: `tex2pdf.directives`
 
-arXiv's next generation TeX compilation based on TexLive Docker container.
-
-See detailed [README.md](tex2pdf/service/README.md)
+Docs?

--- a/tex2pdf-tools/tests/directives/test_directives.py
+++ b/tex2pdf-tools/tests/directives/test_directives.py
@@ -7,24 +7,24 @@ class TestDirectiveManager(unittest.TestCase):
 
     @patch('tex2pdf_tools.directives.os.listdir')
     def test_list_directives_files(self, mock_listdir):
-        mock_listdir.return_value = ['00readme.yaml', '00README.XXX', 'otherfile.txt']
+        mock_listdir.return_value = ['00README.yaml', '00README.XXX', 'otherfile.txt']
         manager = DirectiveManager("dummy_dir")
-        self.assertEqual(manager.list_directives_files(), ['00README.XXX', '00readme.yaml'])
+        self.assertEqual(manager.list_directives_files(), ['00README.XXX', '00README.yaml'])
 
         # Try several bad file names
-        mock_listdir.return_value = ['readme.yaml', '00readme.yaml', '00readmeBackup.yaml',
+        mock_listdir.return_value = ['readme.yaml', '00README.yaml', '00READMEBackup.yaml',
                                      '00README.XXX', '00READMEv2.XXX', 'otherfile.txt']
         manager = DirectiveManager("dummy_dir")
-        self.assertEqual(manager.list_directives_files(), ['00README.XXX', '00readme.yaml'],
-                         "Expect two 00readme files, one v1 and one v2.")
+        self.assertEqual(manager.list_directives_files(), ['00README.XXX', '00README.yaml'],
+                         "Expect two 00README files, one v1 and one v2.")
 
     @patch('tex2pdf_tools.directives.os.listdir')
     def test_get_active_directives_file(self, mock_listdir):
 
         # Case 1: Single v2 file
-        mock_listdir.return_value = ['00readme.yaml', '00README.XXX']
+        mock_listdir.return_value = ['00README.yaml', '00README.XXX']
         manager = DirectiveManager("dummy_dir")
-        self.assertEqual(manager.get_active_directives_file(), '00readme.yaml')
+        self.assertEqual(manager.get_active_directives_file(), '00README.yaml')
 
         # Case 2: No v2 file, single v1 file
         mock_listdir.return_value = ['00README.XXX']
@@ -32,7 +32,7 @@ class TestDirectiveManager(unittest.TestCase):
         self.assertEqual(manager.get_active_directives_file(), '00README.XXX')
 
         # Case 3: Multiple v2 files
-        mock_listdir.return_value = ['00readme.yaml', '00readme.json', '00README.XXX']
+        mock_listdir.return_value = ['00README.yaml', '00README.json', '00README.XXX']
         manager = DirectiveManager("dummy_dir")
         with self.assertRaises(ValueError):
             manager.get_active_directives_file()
@@ -46,12 +46,12 @@ class TestDirectiveManager(unittest.TestCase):
     def test_is_active_directives_file(self, mock_listdir):
         """ """
         # Setup directory listing for the tests
-        mock_listdir.return_value = ['00readme.yaml', '00README.XXX']
+        mock_listdir.return_value = ['00README.yaml', '00README.XXX']
 
         manager = DirectiveManager("dummy_dir")
 
-        # Case 1: Active file is 00readme.yaml
-        self.assertTrue(manager.is_active_directives_file('00readme.yaml'))
+        # Case 1: Active file is 00README.yaml
+        self.assertTrue(manager.is_active_directives_file('00README.yaml'))
         self.assertFalse(manager.is_active_directives_file('00README.XXX'))
         self.assertFalse(manager.is_active_directives_file('otherfile.txt'))
 
@@ -59,7 +59,7 @@ class TestDirectiveManager(unittest.TestCase):
         mock_listdir.return_value = ['00README.XXX']
         manager = DirectiveManager("dummy_dir")
         self.assertTrue(manager.is_active_directives_file('00README.XXX'))
-        self.assertFalse(manager.is_active_directives_file('00readme.yaml'))
+        self.assertFalse(manager.is_active_directives_file('00README.yaml'))
 
 
     @patch('tex2pdf_tools.directives.os.listdir')
@@ -72,8 +72,8 @@ class TestDirectiveManager(unittest.TestCase):
     @patch('tex2pdf_tools.directives.os.listdir')
     def test_is_v2_file(self, mock_listdir):
         manager = DirectiveManager("dummy_dir")
-        self.assertTrue(manager.is_v2_file('00readme.yaml'))
-        self.assertFalse(manager.is_v2_file('00readmejunk.yaml'))
+        self.assertTrue(manager.is_v2_file('00README.yaml'))
+        self.assertFalse(manager.is_v2_file('00READMEjunk.yaml'))
         self.assertFalse(manager.is_v2_file('otherfile.yaml'))
 
     @patch('tex2pdf_tools.directives.os.listdir')
@@ -84,23 +84,23 @@ class TestDirectiveManager(unittest.TestCase):
         self.assertTrue(manager.v1_exists())
 
         # Case 2: v1 file does not exist
-        mock_listdir.return_value = ['00readme.yaml', 'otherfile.txt']
+        mock_listdir.return_value = ['00README.yaml', 'otherfile.txt']
         manager = DirectiveManager("dummy_dir")
         self.assertFalse(manager.v1_exists())
 
         # Case 3: Multiple v2 files
-        mock_listdir.return_value = ['00readme.yaml', '00readme.json', 'otherfile.txt']
+        mock_listdir.return_value = ['00README.yaml', '00README.json', 'otherfile.txt']
         manager = DirectiveManager("dummy_dir")
         with self.assertRaises(ValueError) as context:
             manager.get_active_directives_file()
             manager.v2_exists()
-        self.assertEqual(str(context.exception), 'Only one v2 00readme directives file is allowed.')
+        self.assertEqual(str(context.exception), 'Only one v2 00README directives file is allowed.')
 
 
     @patch('tex2pdf_tools.directives.os.listdir')
     def test_v2_exists(self, mock_listdir):
         # Case 1: v2 file exists
-        mock_listdir.return_value = ['00readme.yaml', 'otherfile.txt']
+        mock_listdir.return_value = ['00README.yaml', 'otherfile.txt']
         manager = DirectiveManager("dummy_dir")
         self.assertTrue(manager.v2_exists())
 
@@ -117,34 +117,34 @@ class TestDirectiveManager(unittest.TestCase):
         self.assertTrue(manager.can_make_active('00README.XXX'))
 
         # Case 2: Existing v2 file, trying to activate another v2 file
-        mock_listdir.return_value = ['00readme.yaml']
+        mock_listdir.return_value = ['00README.yaml']
         manager = DirectiveManager("dummy_dir")
-        self.assertFalse(manager.can_make_active('00readme.json'))
+        self.assertFalse(manager.can_make_active('00README.json'))
 
         # Case 3: Existing v2 file, trying to activate the same v2 file
-        mock_listdir.return_value = ['00readme.yaml']
+        mock_listdir.return_value = ['00README.yaml']
         manager = DirectiveManager("dummy_dir")
-        self.assertTrue(manager.can_make_active('00readme.yaml'))
+        self.assertTrue(manager.can_make_active('00README.yaml'))
 
         # Case 4: Existing v1 file, no v2 file, trying to activate a new v2 file
         mock_listdir.return_value = ['00README.XXX']
         manager = DirectiveManager("dummy_dir")
-        self.assertTrue(manager.can_make_active('00readme.yaml'))
+        self.assertTrue(manager.can_make_active('00README.yaml'))
 
-        # Case 5: Invalid file, not 00readme format
-        mock_listdir.return_value = ['00README.XXX', '00readme.yaml']
+        # Case 5: Invalid file, not 00README format
+        mock_listdir.return_value = ['00README.XXX', '00README.yaml']
         manager = DirectiveManager("dummy_dir")
         self.assertFalse(manager.can_make_active('otherfile.txt'))
 
         # Case 6: Valid v1 file exists, no v2 file, trying to activate another valid v1 file
-        mock_listdir.return_value = ['00README.XXX', '00readme.xxx']
+        mock_listdir.return_value = ['00README.XXX', '00README.xxx']
         manager = DirectiveManager("dummy_dir")
         self.assertTrue(manager.can_make_active('00README.XXX'))
 
         # Case 7: New v2 file can replace existing v1 file if no existing v2
         mock_listdir.return_value = ['00README.XXX', 'otherfile.txt']
         manager = DirectiveManager("dummy_dir")
-        self.assertTrue(manager.can_make_active('00readme.yaml'))
+        self.assertTrue(manager.can_make_active('00README.yaml'))
 
     @patch('tex2pdf_tools.directives.os.listdir')
     def test_add_files_exists(self, mock_listdir):
@@ -169,14 +169,14 @@ class TestDirectiveManager(unittest.TestCase):
         self.assertFalse(manager.is_v2_file('00README.XXX'))
         self.assertTrue(manager.is_active_directives_file('00README.XXX'))
 
-        self.assertTrue(manager.can_make_active('00readme.yaml'))
+        self.assertTrue(manager.can_make_active('00README.yaml'))
         self.assertTrue(manager.v1_exists())
-        self.assertFalse(manager.is_v1_file('00readme.yaml'))
+        self.assertFalse(manager.is_v1_file('00README.yaml'))
         self.assertFalse(manager.v2_exists())
-        self.assertTrue(manager.is_v2_file('00readme.yaml'))
-        self.assertFalse(manager.is_active_directives_file('00readme.yaml'))
+        self.assertTrue(manager.is_v2_file('00README.yaml'))
+        self.assertFalse(manager.is_active_directives_file('00README.yaml'))
 
-        mock_listdir.return_value = ['00readme.yaml', '00README.XXX']
+        mock_listdir.return_value = ['00README.yaml', '00README.XXX']
         manager = DirectiveManager("dummy_dir")
 
         self.assertFalse(manager.can_make_active('00README.XXX'), 'No longer option for active')
@@ -186,17 +186,17 @@ class TestDirectiveManager(unittest.TestCase):
         self.assertFalse(manager.is_v2_file('00README.XXX'))
         self.assertFalse(manager.is_active_directives_file('00README.XXX'))
 
-        self.assertTrue(manager.can_make_active('00readme.yaml'))
+        self.assertTrue(manager.can_make_active('00README.yaml'))
         self.assertTrue(manager.v1_exists())
-        self.assertFalse(manager.is_v1_file('00readme.yaml'))
+        self.assertFalse(manager.is_v1_file('00README.yaml'))
         self.assertTrue(manager.v2_exists())
-        self.assertTrue(manager.is_v2_file('00readme.yaml'))
-        self.assertTrue(manager.is_active_directives_file('00readme.yaml'))
+        self.assertTrue(manager.is_v2_file('00README.yaml'))
+        self.assertTrue(manager.is_active_directives_file('00README.yaml'))
 
-        mock_listdir.return_value = ['00readme.json', '00readme.yaml',
+        mock_listdir.return_value = ['00README.json', '00README.yaml',
                                      '00README.XXX']
         manager = DirectiveManager("dummy_dir")
-        error_str = 'Only one v2 00readme directives file is allowed.'
+        error_str = 'Only one v2 00README directives file is allowed.'
         #self.assertFalse(manager.can_make_active('00README.XXX'), 'No longer option for active')
         with self.assertRaises(ValueError) as context:
             manager.can_make_active('00README.XXX')
@@ -212,21 +212,21 @@ class TestDirectiveManager(unittest.TestCase):
             manager.is_active_directives_file('00README.XXX')
         self.assertEqual(str(context.exception), error_str)
         with self.assertRaises(ValueError) as context:
-            manager.can_make_active('00readme.yaml')
+            manager.can_make_active('00README.yaml')
         self.assertEqual(str(context.exception), error_str)
         self.assertTrue(manager.v1_exists())
-        self.assertFalse(manager.is_v1_file('00readme.yaml'))
+        self.assertFalse(manager.is_v1_file('00README.yaml'))
         with self.assertRaises(ValueError) as context:
             manager.get_active_directives_file()
             manager.v2_exists()
-        self.assertTrue(manager.is_v2_file('00readme.yaml'))
+        self.assertTrue(manager.is_v2_file('00README.yaml'))
         with self.assertRaises(ValueError) as context:
             manager.get_active_directives_file()
-            manager.is_active_directives_file('00readme.yaml')
+            manager.is_active_directives_file('00README.yaml')
 
 
 
-        mock_listdir.return_value = ['00readme.yaml', '00README.XXX']
+        mock_listdir.return_value = ['00README.yaml', '00README.XXX']
         manager = DirectiveManager("dummy_dir")
         self.assertTrue(manager.v2_exists())
         mock_listdir.return_value = ['00README.XXX']

--- a/tex2pdf-tools/tex2pdf_tools/directives/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/directives/__init__.py
@@ -1,7 +1,7 @@
 """
 Directives Manager.
 
-This package enforces policies related to the directives or 00readme file. The main
+This package enforces policies related to the directives or 00README file. The main
 policy is to allow a single v2 directives file. When a document contains a legacy v1
 00README.XXX and no v2 directives file, the 00README.XXX will be converted to a v2
 file, with the 00README.XXX being retained for the historical record.

--- a/tex2pdf-tools/tex2pdf_tools/directives/__main__.py
+++ b/tex2pdf-tools/tex2pdf_tools/directives/__main__.py
@@ -22,9 +22,9 @@ def main():
         "-c",
         "--create_file",
         nargs="?",
-        const="00readme",
+        const="00README",
         help="Create a new directives file with the specified "
-        'format. Defaults to creating "00readme" if no basename is provided.',
+        'format. Defaults to creating "00README" if no basename is provided.',
     )
     parser.add_argument("-d", "--debug", action="store_true", help="Debug setting.")
     parser.add_argument("-D", "--details", action="store_true", help="List all directives files with format.")
@@ -187,7 +187,7 @@ def main():
         except ValueError as e:
             print(f"Error: {e}")
 
-    # Collect and digest information we need from 00readme
+    # Collect and digest information we need from 00README
     directives = {}
     #    node = {
     #        "ignore": []
@@ -202,7 +202,7 @@ def main():
     # print(f"Serial:{serial}")
     # exit(0)
     # Default behavior will be to examine the root directory and
-    # process the active 00readme and the preflight information.
+    # process the active 00README and the preflight information.
     preflight_data = manager.load_preflight_data(args.preflight_file)
     #    directives['ignore'] = node
     directives["preflight"] = preflight_data

--- a/tex2pdf-tools/tex2pdf_tools/directives/directives.py
+++ b/tex2pdf-tools/tex2pdf_tools/directives/directives.py
@@ -25,15 +25,15 @@ def serialize_data(data: dict, format: str) -> str:
     Returns:
         str: Serialized string.
     """
-    if format == "yaml":
-        return yaml.dump(data)
-    elif format == "json":
-        return json.dumps(data, indent=4)
-    elif format == "toml":
-        return toml.dumps(data)
-    else:
-        raise ValueError("Unsupported format. Use 'yaml', 'json', or 'toml'.")
-
+    match format:
+        case "yaml":
+            return yaml.dump(data)
+        case "json":
+            return json.dumps(data, indent=4)
+        case "toml":
+            return toml.dumps(data)
+        case _:
+            raise ValueError("Unsupported format. Use 'yaml', 'json', or 'toml'.")
 
 def write_readme_file(file_path: str, content: str) -> None:
     """
@@ -57,9 +57,9 @@ class DirectiveManager:
         self.root_dir = root_dir
         self.src_dir = src_dir if src_dir is not None else f"{self.root_dir}/src"
         self.directives_files = self.list_directives_files()
-        self.preflight_module = None  # Initialize preflight_module as None
-        self.preflight_data_not_found = False
+        self.preflight_module = None
         self.preflight_hierarchy = None
+        self.preflight_data_not_found = False
         self.readme_object = None
 
     def load_preflight_data(self, preflight_file_arg: str | None = None):
@@ -78,7 +78,6 @@ class DirectiveManager:
         try:
             top_level_files = []
             include_all_files = True
-            # hierarchy = self.preflight_module.load_preflight_data(preflight_file)
             hierarchy = self.preflight_module.build_hierarchy(
                 specified_top_level_files=top_level_files, include_all_files=include_all_files
             )
@@ -96,7 +95,7 @@ class DirectiveManager:
         List all directives files in the root directory.
 
         This routine is using the filename to determine whether the file
-        is a 00readme file. The contents are not validated.
+        is a 00README file. The contents are not validated.
 
         Note: An active or historical 00README.XXX is allowed. We expect to
         find at most one v2 directives file in all newer articles that rely
@@ -118,7 +117,7 @@ class DirectiveManager:
             bool: True if the file is a directives file, False otherwise.
         """
         name, ext = os.path.splitext(filename)
-        return name.lower() == "00readme" and ext.lower() in DIRECTIVE_EXTS
+        return name.upper() == "00README" and ext.lower() in DIRECTIVE_EXTS
 
     def get_active_directives_file(self) -> str:
         """
@@ -133,7 +132,7 @@ class DirectiveManager:
         """
         v2_files = [f for f in self.directives_files if self.is_v2_file(f)]
         if len(v2_files) > 1:
-            raise ValueError("Only one v2 00readme directives file is allowed.")
+            raise ValueError("Only one v2 00README directives file is allowed.")
         elif v2_files:
             return v2_files[0]
 
@@ -153,7 +152,7 @@ class DirectiveManager:
             bool: True if the file is a v2 directives file, False otherwise.
         """
         name, ext = os.path.splitext(filename)
-        return name.lower() == "00readme" and ext.lower() in [".yaml", ".yml", ".json", ".toml"]
+        return name.upper() == "00README" and ext.lower() in [".yaml", ".yml", ".json", ".toml"]
 
     @staticmethod
     def is_v1_file(filename: str) -> bool:
@@ -167,7 +166,7 @@ class DirectiveManager:
             bool: True if the file is a v1 directives file, False otherwise.
         """
         name, ext = os.path.splitext(filename)
-        return name.lower() == "00readme" and ext.lower() == ".xxx"
+        return name.upper() == "00README" and ext.lower() == ".xxx"
 
     def v1_exists(self) -> bool:
         """
@@ -209,7 +208,7 @@ class DirectiveManager:
             bool: True if the file can be made active, False otherwise.
         """
         name, ext = os.path.splitext(filename)
-        if name.lower() != "00readme" or ext.lower() not in DIRECTIVE_EXTS:
+        if name.upper() != "00README" or ext.lower() not in DIRECTIVE_EXTS:
             return False
 
         if self.is_active_directives_file(filename):
@@ -250,7 +249,7 @@ class DirectiveManager:
         zzrm = ZeroZeroReadMe(self.root_dir)
         data = zzrm.to_dict()
 
-        new_00readme_path = os.path.join(self.root_dir, f"00readme.{dest_format}")
+        new_00readme_path = os.path.join(self.root_dir, f"00README.{dest_format}")
         serialized_data = serialize_data(data, dest_format)
         write_readme_file(new_00readme_path, serialized_data)
 
@@ -271,13 +270,13 @@ class DirectiveManager:
         return self.readme_object.ignores
 
     def create_directives_file(
-        self, basename: str = "00readme", elements: dict | None = None, format: str = "json", force: bool = False
+        self, basename: str = "00README", elements: dict | None = None, format: str = "json", force: bool = False
     ):
         """
         Create a new directives file with the specified format.
 
         Args:
-            basename (str, optional): Base name of the file to create (without extension). Defaults to "00readme".
+            basename (str, optional): Base name of the file to create (without extension). Defaults to "00README".
             elements (dict, optional): Elements to write to the file.
             format (str, optional): Format of the file (json, yaml, toml). Defaults to "json".
             force (bool, optional): Whether to force creation even if it would not be active. Defaults to False.

--- a/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
@@ -167,15 +167,15 @@ class ZeroZeroReadMe:
         Load a 00README file.
 
         POLICY:
-        * only files named 00readme.EXT with EXT in either
+        * only files named 00README.EXT with EXT in either
           ZZRM_V1_EXTS or ZZRM_V2_EXTS are accepted.
 
         Raises:
             * ZZRMUnsupportedFileError if file name is not recognized.
         """
         stem, ext = os.path.splitext(os.path.basename(file))
-        if stem.lower() != "00readme":
-            raise ZZRMUnsupportedFileError(f"File {file} must start with 00readme (case-insensitive)")
+        if stem.upper() != "00README":
+            raise ZZRMUnsupportedFileError(f"File {file} must start with 00README (case-insensitive)")
         if ext.lower() in ZZRM_V1_EXTS:
             self._fetch_00readme_data(file, 1)
         elif ext.lower() in ZZRM_V2_EXTS:
@@ -206,7 +206,7 @@ class ZeroZeroReadMe:
             if filename[0] > "0":  # Should I use ord()?
                 break
             (stem, ext) = os.path.splitext(filename)
-            if stem.lower() != "00readme":
+            if stem.upper() != "00README":
                 continue
             if ext.lower() in ZZRM_V1_EXTS:
                 zzrms_v1.append(filename)
@@ -218,13 +218,13 @@ class ZeroZeroReadMe:
                 continue
 
         if len(zzrms_v2) > 1:
-            raise ZZRMMultipleFilesError("Only one v2 00readme directives file is allowed.")
+            raise ZZRMMultipleFilesError("Only one v2 00README directives file is allowed.")
         elif len(zzrms_v2) > 0:
             self._fetch_00readme_data(os.path.join(in_dir, zzrms_v2[0]), 2)
             return
 
         if len(zzrms_v1) > 1:
-            raise ZZRMMultipleFilesError("Only one v1 00readme directives file is allowed.")
+            raise ZZRMMultipleFilesError("Only one v1 00README directives file is allowed.")
         elif len(zzrms_v1) > 0:
             self._fetch_00readme_data(os.path.join(in_dir, zzrms_v1[0]), 1)
             return


### PR DESCRIPTION
If I tested this correctly, this caps normalization successfully adapts to the change in #107 and once again leads to operational builds on dev6.

Simple motivation: The official file name is an all-caps convention (`00README`), so keep all code that references the strings for those files strictly all-caps.