### PR TITLE
[ARXIVCE-3289] detect incompatible bbl version and report via preflight issues

### DIFF
--- a/tex2pdf-tools/tests/preflight/fixture/bbl_version_good/bla.bbl
+++ b/tex2pdf-tools/tests/preflight/fixture/bbl_version_good/bla.bbl
@@ -1,0 +1,112 @@
+% $ biblatex auxiliary file $
+% $ biblatex bbl format version 3.2 $
+% Do not modify the above lines!
+%
+% This is an auxiliary file used by the 'biblatex' package.
+% This file may safely be deleted. It will be recreated by
+% biber as required.
+%
+\begingroup
+\makeatletter
+\@ifundefined{ver@biblatex.sty}
+  {\@latex@error
+     {Missing 'biblatex' package}
+     {The bibliography requires the 'biblatex' package.}
+      \aftergroup\endinput}
+  {}
+\endgroup
+
+
+\refsection{0}
+  \datalist[entry]{nyt/global//global/global}
+    \entry{kastenholz}{article}{}
+      \name{author}{2}{}{%
+        {{un=0,uniquepart=base,hash=96123eb8cd99ad0efc1991ed77185c47}{%
+           family={Kastenholz},
+           familyi={K\bibinitperiod},
+           given={M.\bibnamedelimi A.},
+           giveni={M\bibinitperiod\bibinitdelim A\bibinitperiod},
+           givenun=0}}%
+        {{un=0,uniquepart=base,hash=96e2e3d04ba287dbd118b54dda8b0f00}{%
+           family={Hünenberger},
+           familyi={H\bibinitperiod},
+           given={Philippe\bibnamedelima H.},
+           giveni={P\bibinitperiod\bibinitdelim H\bibinitperiod},
+           givenun=0}}%
+      }
+      \strng{namehash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{fullhash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{bibnamehash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{authorbibnamehash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{authornamehash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{authorfullhash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \field{sortinit}{K}
+      \field{sortinithash}{c02bf6bff1c488450c352b40f5d853ab}
+      \field{extradatescope}{labelyear}
+      \field{labeldatesource}{}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{abstract}{The computation of ionic solvation free energies from atomistic simulations is a surprisingly difficult problem that has found no satisfactory solution for more than 15 years. The reason is that the charging free energies evaluated from such simulations are affected by very large errors. One of these is related to the choice of a specific convention for summing up the contributions of solvent charges to the electrostatic potential in the ionic cavity, namely, on the basis of point charges within entire solvent molecules (M scheme) or on the basis of individual point charges (P scheme). The use of an inappropriate convention may lead to a charge-independent offset in the calculated potential, which depends on the details of the summation scheme, on the quadrupole-moment trace of the solvent molecule, and on the approximate form used to represent electrostatic interactions in the system. However, whether the M or P scheme (if any) represents the appropriate convention is still a matter of on-going debate. The goal of the present article is to settle this long-standing controversy by carefully analyzing (both analytically and numerically) the properties of the electrostatic potential in molecular liquids (and inside cavities within them).}
+      \field{annotation}{An \texttt{article} entry with an \texttt{eid} and a \texttt{doi} field. Note that the \textsc{doi} is transformed into a clickable link if \texttt{hyperref} support has been enabled}
+      \field{eid}{124106}
+      \field{indextitle}{Computation of ionic solvation free energies}
+      \field{journaltitle}{J.~Chem. Phys.}
+      \field{langid}{english}
+      \field{langidopts}{variant=american}
+      \field{subtitle}{{I}. {The} electrostatic potential in molecular liquids}
+      \field{title}{Computation of methodology\hyphen independent ionic solvation free energies from molecular simulations}
+      \field{volume}{124}
+      \field{year}{2006}
+      \field{dateera}{ce}
+      \verb{doi}
+      \verb 10.1063/1.2172593
+      \endverb
+    \endentry
+    \entry{sigfridsson}{article}{}
+      \name{author}{2}{}{%
+        {{un=0,uniquepart=base,hash=484061f383fb3b729627e12ab42c1963}{%
+           family={Sigfridsson},
+           familyi={S\bibinitperiod},
+           given={Emma},
+           giveni={E\bibinitperiod},
+           givenun=0}}%
+        {{un=0,uniquepart=base,hash=b7e299b632e5db12681c2decc8ce023f}{%
+           family={Ryde},
+           familyi={R\bibinitperiod},
+           given={Ulf},
+           giveni={U\bibinitperiod},
+           givenun=0}}%
+      }
+      \strng{namehash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{fullhash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{bibnamehash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{authorbibnamehash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{authornamehash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{authorfullhash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \field{sortinit}{S}
+      \field{sortinithash}{b164b07b29984b41daf1e85279fbc5ab}
+      \field{extradatescope}{labelyear}
+      \field{labeldatesource}{}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{abstract}{Four methods for deriving partial atomic charges from the quantum chemical electrostatic potential (CHELP, CHELPG, Merz-Kollman, and RESP) have been compared and critically evaluated. It is shown that charges strongly depend on how and where the potential points are selected. Two alternative methods are suggested to avoid the arbitrariness in the point-selection schemes and van der Waals exclusion radii: CHELP-BOW, which also estimates the charges from the electrostatic potential, but with potential points that are Boltzmann-weighted after their occurrence in actual simulations using the energy function of the program in which the charges will be used, and CHELMO, which estimates the charges directly from the electrostatic multipole moments. Different criteria for the quality of the charges are discussed.}
+      \field{annotation}{An \texttt{article} entry with \texttt{volume}, \texttt{number}, and \texttt{doi} fields. Note that the \textsc{doi} is transformed into a clickable link if \texttt{hyperref} support has been enabled}
+      \field{indextitle}{Methods for deriving atomic charges}
+      \field{journaltitle}{Journal of Computational Chemistry}
+      \field{langid}{english}
+      \field{langidopts}{variant=american}
+      \field{number}{4}
+      \field{title}{Comparison of methods for deriving atomic charges from the electrostatic potential and moments}
+      \field{volume}{19}
+      \field{year}{1998}
+      \field{dateera}{ce}
+      \field{pages}{377\bibrangedash 395}
+      \range{pages}{19}
+      \verb{doi}
+      \verb 10.1002/(SICI)1096-987X(199803)19:4<377::AID-JCC1>3.0.CO;2-P
+      \endverb
+    \endentry
+  \enddatalist
+\endrefsection
+\endinput
+

--- a/tex2pdf-tools/tests/preflight/fixture/bbl_version_good/bla.bib
+++ b/tex2pdf-tools/tests/preflight/fixture/bbl_version_good/bla.bib
@@ -1,0 +1,83 @@
+@string{anch-ie = {Angew.~Chem. Int.~Ed.}}
+@string{cup     = {Cambridge University Press}}
+@string{dtv     = {Deutscher Taschenbuch-Verlag}}
+@string{hup     = {Harvard University Press}}
+@string{jams    = {J.~Amer. Math. Soc.}}
+@string{jchph   = {J.~Chem. Phys.}}
+@string{jomch   = {J.~Organomet. Chem.}}
+@string{pup     = {Princeton University Press}}
+
+@article{kastenholz,
+  author       = {Kastenholz, M. A. and H{\"u}nenberger, Philippe H.},
+  title        = {Computation of methodology\hyphen independent ionic solvation
+                  free energies from molecular simulations},
+  journaltitle = jchph,
+  date         = 2006,
+  subtitle     = {{I}. {The} electrostatic potential in molecular liquids},
+  volume       = 124,
+  eid          = 124106,
+  doi          = {10.1063/1.2172593},
+  langid       = {english},
+  langidopts   = {variant=american},
+  indextitle   = {Computation of ionic solvation free energies},
+  annotation   = {An \texttt{article} entry with an \texttt{eid} and a
+                  \texttt{doi} field. Note that the \textsc{doi} is transformed
+                  into a clickable link if \texttt{hyperref} support has been
+                  enabled},
+  abstract     = {The computation of ionic solvation free energies from
+                  atomistic simulations is a surprisingly difficult problem that
+                  has found no satisfactory solution for more than 15 years. The
+                  reason is that the charging free energies evaluated from such
+                  simulations are affected by very large errors. One of these is
+                  related to the choice of a specific convention for summing up
+                  the contributions of solvent charges to the electrostatic
+                  potential in the ionic cavity, namely, on the basis of point
+                  charges within entire solvent molecules (M scheme) or on the
+                  basis of individual point charges (P scheme). The use of an
+                  inappropriate convention may lead to a charge-independent
+                  offset in the calculated potential, which depends on the
+                  details of the summation scheme, on the quadrupole-moment
+                  trace of the solvent molecule, and on the approximate form
+                  used to represent electrostatic interactions in the
+                  system. However, whether the M or P scheme (if any) represents
+                  the appropriate convention is still a matter of on-going
+                  debate. The goal of the present article is to settle this
+                  long-standing controversy by carefully analyzing (both
+                  analytically and numerically) the properties of the
+                  electrostatic potential in molecular liquids (and inside
+                  cavities within them).},
+}
+
+@article{sigfridsson,
+  author       = {Sigfridsson, Emma and Ryde, Ulf},
+  title        = {Comparison of methods for deriving atomic charges from the
+                  electrostatic potential and moments},
+  journaltitle = {Journal of Computational Chemistry},
+  date         = 1998,
+  volume       = 19,
+  number       = 4,
+  pages        = {377-395},
+  doi          = {10.1002/(SICI)1096-987X(199803)19:4<377::AID-JCC1>3.0.CO;2-P},
+  langid       = {english},
+  langidopts   = {variant=american},
+  indextitle   = {Methods for deriving atomic charges},
+  annotation   = {An \texttt{article} entry with \texttt{volume},
+                  \texttt{number}, and \texttt{doi} fields. Note that the
+                  \textsc{doi} is transformed into a clickable link if
+                  \texttt{hyperref} support has been enabled},
+  abstract     = {Four methods for deriving partial atomic charges from the
+                  quantum chemical electrostatic potential (CHELP, CHELPG,
+                  Merz-Kollman, and RESP) have been compared and critically
+                  evaluated. It is shown that charges strongly depend on how and
+                  where the potential points are selected. Two alternative
+                  methods are suggested to avoid the arbitrariness in the
+                  point-selection schemes and van der Waals exclusion radii:
+                  CHELP-BOW, which also estimates the charges from the
+                  electrostatic potential, but with potential points that are
+                  Boltzmann-weighted after their occurrence in actual
+                  simulations using the energy function of the program in which
+                  the charges will be used, and CHELMO, which estimates the
+                  charges directly from the electrostatic multipole
+                  moments. Different criteria for the quality of the charges are
+                  discussed.},
+}

--- a/tex2pdf-tools/tests/preflight/fixture/bbl_version_good/bla.tex
+++ b/tex2pdf-tools/tests/preflight/fixture/bbl_version_good/bla.tex
@@ -1,0 +1,26 @@
+\documentclass[]{article}
+
+\usepackage[autostyle]{csquotes}
+
+\usepackage[
+    backend=biber,
+    style=authoryear-icomp,
+    sortlocale=de_DE,
+    natbib=true,
+    url=false, 
+    doi=true,
+    eprint=false
+]{biblatex}
+\addbibresource{bla.bib}
+
+\usepackage[]{hyperref}
+\hypersetup{
+    colorlinks=true,
+}
+
+%% ##############################
+\begin{document}
+    Lorem ipsum dolor sit amet~\citep{kastenholz}.
+    At vero eos et accusam et justo duo dolores et ea rebum~\citet{sigfridsson}.
+    \printbibliography 
+\end{document}

--- a/tex2pdf-tools/tests/preflight/fixture/bbl_version_mismatch/bla.bbl
+++ b/tex2pdf-tools/tests/preflight/fixture/bbl_version_mismatch/bla.bbl
@@ -1,0 +1,116 @@
+% $ biblatex auxiliary file $
+% $ biblatex bbl format version 3.3 $
+% Do not modify the above lines!
+%
+% This is an auxiliary file used by the 'biblatex' package.
+% This file may safely be deleted. It will be recreated by
+% biber as required.
+%
+\begingroup
+\makeatletter
+\@ifundefined{ver@biblatex.sty}
+  {\@latex@error
+     {Missing 'biblatex' package}
+     {The bibliography requires the 'biblatex' package.}
+      \aftergroup\endinput}
+  {}
+\endgroup
+
+
+\refsection{0}
+  \datalist[entry]{nyt/global//global/global/global}
+    \entry{kastenholz}{article}{}{}
+      \name{author}{2}{}{%
+        {{un=0,uniquepart=base,hash=96123eb8cd99ad0efc1991ed77185c47}{%
+           family={Kastenholz},
+           familyi={K\bibinitperiod},
+           given={M.\bibnamedelimi A.},
+           giveni={M\bibinitperiod\bibinitdelim A\bibinitperiod},
+           givenun=0}}%
+        {{un=0,uniquepart=base,hash=96e2e3d04ba287dbd118b54dda8b0f00}{%
+           family={Hünenberger},
+           familyi={H\bibinitperiod},
+           given={Philippe\bibnamedelima H.},
+           giveni={P\bibinitperiod\bibinitdelim H\bibinitperiod},
+           givenun=0}}%
+      }
+      \strng{namehash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{fullhash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{fullhashraw}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{bibnamehash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{authorbibnamehash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{authornamehash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{authorfullhash}{5e2ee92ca164b2cda223006e47a16bd9}
+      \strng{authorfullhashraw}{5e2ee92ca164b2cda223006e47a16bd9}
+      \field{sortinit}{K}
+      \field{sortinithash}{c02bf6bff1c488450c352b40f5d853ab}
+      \field{extradatescope}{labelyear}
+      \field{labeldatesource}{}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{abstract}{The computation of ionic solvation free energies from atomistic simulations is a surprisingly difficult problem that has found no satisfactory solution for more than 15 years. The reason is that the charging free energies evaluated from such simulations are affected by very large errors. One of these is related to the choice of a specific convention for summing up the contributions of solvent charges to the electrostatic potential in the ionic cavity, namely, on the basis of point charges within entire solvent molecules (M scheme) or on the basis of individual point charges (P scheme). The use of an inappropriate convention may lead to a charge-independent offset in the calculated potential, which depends on the details of the summation scheme, on the quadrupole-moment trace of the solvent molecule, and on the approximate form used to represent electrostatic interactions in the system. However, whether the M or P scheme (if any) represents the appropriate convention is still a matter of on-going debate. The goal of the present article is to settle this long-standing controversy by carefully analyzing (both analytically and numerically) the properties of the electrostatic potential in molecular liquids (and inside cavities within them).}
+      \field{annotation}{An \texttt{article} entry with an \texttt{eid} and a \texttt{doi} field. Note that the \textsc{doi} is transformed into a clickable link if \texttt{hyperref} support has been enabled}
+      \field{eid}{124106}
+      \field{indextitle}{Computation of ionic solvation free energies}
+      \field{journaltitle}{J.~Chem. Phys.}
+      \field{langid}{english}
+      \field{langidopts}{variant=american}
+      \field{subtitle}{{I}. {The} electrostatic potential in molecular liquids}
+      \field{title}{Computation of methodology\hyphen independent ionic solvation free energies from molecular simulations}
+      \field{volume}{124}
+      \field{year}{2006}
+      \field{dateera}{ce}
+      \verb{doi}
+      \verb 10.1063/1.2172593
+      \endverb
+    \endentry
+    \entry{sigfridsson}{article}{}{}
+      \name{author}{2}{}{%
+        {{un=0,uniquepart=base,hash=484061f383fb3b729627e12ab42c1963}{%
+           family={Sigfridsson},
+           familyi={S\bibinitperiod},
+           given={Emma},
+           giveni={E\bibinitperiod},
+           givenun=0}}%
+        {{un=0,uniquepart=base,hash=b7e299b632e5db12681c2decc8ce023f}{%
+           family={Ryde},
+           familyi={R\bibinitperiod},
+           given={Ulf},
+           giveni={U\bibinitperiod},
+           givenun=0}}%
+      }
+      \strng{namehash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{fullhash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{fullhashraw}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{bibnamehash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{authorbibnamehash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{authornamehash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{authorfullhash}{d9015d9f08448ab0cb194bd964d7b44b}
+      \strng{authorfullhashraw}{d9015d9f08448ab0cb194bd964d7b44b}
+      \field{sortinit}{S}
+      \field{sortinithash}{b164b07b29984b41daf1e85279fbc5ab}
+      \field{extradatescope}{labelyear}
+      \field{labeldatesource}{}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{abstract}{Four methods for deriving partial atomic charges from the quantum chemical electrostatic potential (CHELP, CHELPG, Merz-Kollman, and RESP) have been compared and critically evaluated. It is shown that charges strongly depend on how and where the potential points are selected. Two alternative methods are suggested to avoid the arbitrariness in the point-selection schemes and van der Waals exclusion radii: CHELP-BOW, which also estimates the charges from the electrostatic potential, but with potential points that are Boltzmann-weighted after their occurrence in actual simulations using the energy function of the program in which the charges will be used, and CHELMO, which estimates the charges directly from the electrostatic multipole moments. Different criteria for the quality of the charges are discussed.}
+      \field{annotation}{An \texttt{article} entry with \texttt{volume}, \texttt{number}, and \texttt{doi} fields. Note that the \textsc{doi} is transformed into a clickable link if \texttt{hyperref} support has been enabled}
+      \field{indextitle}{Methods for deriving atomic charges}
+      \field{journaltitle}{Journal of Computational Chemistry}
+      \field{langid}{english}
+      \field{langidopts}{variant=american}
+      \field{number}{4}
+      \field{title}{Comparison of methods for deriving atomic charges from the electrostatic potential and moments}
+      \field{volume}{19}
+      \field{year}{1998}
+      \field{dateera}{ce}
+      \field{pages}{377\bibrangedash 395}
+      \range{pages}{19}
+      \verb{doi}
+      \verb 10.1002/(SICI)1096-987X(199803)19:4<377::AID-JCC1>3.0.CO;2-P
+      \endverb
+    \endentry
+  \enddatalist
+\endrefsection
+\endinput
+

--- a/tex2pdf-tools/tests/preflight/fixture/bbl_version_mismatch/bla.bib
+++ b/tex2pdf-tools/tests/preflight/fixture/bbl_version_mismatch/bla.bib
@@ -1,0 +1,83 @@
+@string{anch-ie = {Angew.~Chem. Int.~Ed.}}
+@string{cup     = {Cambridge University Press}}
+@string{dtv     = {Deutscher Taschenbuch-Verlag}}
+@string{hup     = {Harvard University Press}}
+@string{jams    = {J.~Amer. Math. Soc.}}
+@string{jchph   = {J.~Chem. Phys.}}
+@string{jomch   = {J.~Organomet. Chem.}}
+@string{pup     = {Princeton University Press}}
+
+@article{kastenholz,
+  author       = {Kastenholz, M. A. and H{\"u}nenberger, Philippe H.},
+  title        = {Computation of methodology\hyphen independent ionic solvation
+                  free energies from molecular simulations},
+  journaltitle = jchph,
+  date         = 2006,
+  subtitle     = {{I}. {The} electrostatic potential in molecular liquids},
+  volume       = 124,
+  eid          = 124106,
+  doi          = {10.1063/1.2172593},
+  langid       = {english},
+  langidopts   = {variant=american},
+  indextitle   = {Computation of ionic solvation free energies},
+  annotation   = {An \texttt{article} entry with an \texttt{eid} and a
+                  \texttt{doi} field. Note that the \textsc{doi} is transformed
+                  into a clickable link if \texttt{hyperref} support has been
+                  enabled},
+  abstract     = {The computation of ionic solvation free energies from
+                  atomistic simulations is a surprisingly difficult problem that
+                  has found no satisfactory solution for more than 15 years. The
+                  reason is that the charging free energies evaluated from such
+                  simulations are affected by very large errors. One of these is
+                  related to the choice of a specific convention for summing up
+                  the contributions of solvent charges to the electrostatic
+                  potential in the ionic cavity, namely, on the basis of point
+                  charges within entire solvent molecules (M scheme) or on the
+                  basis of individual point charges (P scheme). The use of an
+                  inappropriate convention may lead to a charge-independent
+                  offset in the calculated potential, which depends on the
+                  details of the summation scheme, on the quadrupole-moment
+                  trace of the solvent molecule, and on the approximate form
+                  used to represent electrostatic interactions in the
+                  system. However, whether the M or P scheme (if any) represents
+                  the appropriate convention is still a matter of on-going
+                  debate. The goal of the present article is to settle this
+                  long-standing controversy by carefully analyzing (both
+                  analytically and numerically) the properties of the
+                  electrostatic potential in molecular liquids (and inside
+                  cavities within them).},
+}
+
+@article{sigfridsson,
+  author       = {Sigfridsson, Emma and Ryde, Ulf},
+  title        = {Comparison of methods for deriving atomic charges from the
+                  electrostatic potential and moments},
+  journaltitle = {Journal of Computational Chemistry},
+  date         = 1998,
+  volume       = 19,
+  number       = 4,
+  pages        = {377-395},
+  doi          = {10.1002/(SICI)1096-987X(199803)19:4<377::AID-JCC1>3.0.CO;2-P},
+  langid       = {english},
+  langidopts   = {variant=american},
+  indextitle   = {Methods for deriving atomic charges},
+  annotation   = {An \texttt{article} entry with \texttt{volume},
+                  \texttt{number}, and \texttt{doi} fields. Note that the
+                  \textsc{doi} is transformed into a clickable link if
+                  \texttt{hyperref} support has been enabled},
+  abstract     = {Four methods for deriving partial atomic charges from the
+                  quantum chemical electrostatic potential (CHELP, CHELPG,
+                  Merz-Kollman, and RESP) have been compared and critically
+                  evaluated. It is shown that charges strongly depend on how and
+                  where the potential points are selected. Two alternative
+                  methods are suggested to avoid the arbitrariness in the
+                  point-selection schemes and van der Waals exclusion radii:
+                  CHELP-BOW, which also estimates the charges from the
+                  electrostatic potential, but with potential points that are
+                  Boltzmann-weighted after their occurrence in actual
+                  simulations using the energy function of the program in which
+                  the charges will be used, and CHELMO, which estimates the
+                  charges directly from the electrostatic multipole
+                  moments. Different criteria for the quality of the charges are
+                  discussed.},
+}

--- a/tex2pdf-tools/tests/preflight/fixture/bbl_version_mismatch/bla.tex
+++ b/tex2pdf-tools/tests/preflight/fixture/bbl_version_mismatch/bla.tex
@@ -1,0 +1,26 @@
+\documentclass[]{article}
+
+\usepackage[autostyle]{csquotes}
+
+\usepackage[
+    backend=biber,
+    style=authoryear-icomp,
+    sortlocale=de_DE,
+    natbib=true,
+    url=false, 
+    doi=true,
+    eprint=false
+]{biblatex}
+\addbibresource{bla.bib}
+
+\usepackage[]{hyperref}
+\hypersetup{
+    colorlinks=true,
+}
+
+%% ##############################
+\begin{document}
+    Lorem ipsum dolor sit amet~\citep{kastenholz}.
+    At vero eos et accusam et justo duo dolores et ea rebum~\citet{sigfridsson}.
+    \printbibliography 
+\end{document}


### PR DESCRIPTION
Also  set the BibProcessor to biber in case we detect a biblatex file.

Output for the error case (mismatch version):
```
   "tex_files" : [ ....
      {
         "contains_documentclass" : true,
         "filename" : "bla.tex",
         "hyperref_found" : true,
         "issues" : [
            {
               "filename" : "bla.bbl",
               "info" : "Expected 3.2 but got 3.3",
               "key" : "bbl_version_mismatch"
            }
         ],
         "language" : "latex",
         "used_other_files" : [
            "bla.bbl"
         ]
      }
   .... ]
```