### PR TITLE
[ARXIVCE-3363] deal with same basename for multiple files

### DIFF
--- a/tex2pdf-tools/tests/preflight/fixture/overlapping-filenames/article.tex
+++ b/tex2pdf-tools/tests/preflight/fixture/overlapping-filenames/article.tex
@@ -1,0 +1,3 @@
+
+Test test tes
+

--- a/tex2pdf-tools/tests/preflight/fixture/overlapping-filenames/main.tex
+++ b/tex2pdf-tools/tests/preflight/fixture/overlapping-filenames/main.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+Hello
+\include{article}
+World
+\end{document}

--- a/tex2pdf-tools/tests/preflight/test_preflight.py
+++ b/tex2pdf-tools/tests/preflight/test_preflight.py
@@ -341,9 +341,20 @@ class TestPreflight(unittest.TestCase):
         pf: PreflightResponse = generate_preflight_response(dir_path)
         self.assertEqual(pf.status.key.value, "success")
         self.assertEqual(len(pf.detected_toplevel_files), 1)
-        print(pf)
         self.assertEqual(
             pf.detected_toplevel_files[0].process.compiler.model_dump_json(exclude_none=True, exclude_defaults=True),
             """{"engine":"tex","lang":"latex","output":"pdf","postp":"none"}""",
         )
 
+    def test_overlapping_filenames(self):
+        """Test smae filename for multiple file types."""
+        dir_path = os.path.join(self.fixture_dir, "overlapping-filenames")
+        pf: PreflightResponse = generate_preflight_response(dir_path)
+        self.assertEqual(pf.status.key.value, "success")
+        self.assertEqual(len(pf.detected_toplevel_files), 1)
+        found_main = False
+        for tf in pf.tex_files:
+            if tf.filename == "main.tex":
+                found_main = True
+                self.assertEqual(sorted(tf.used_tex_files), ["article.tex"])
+        assert found_main


### PR DESCRIPTION
We need to make sure that searching for article.cls (system file) and article.tex (provided by author) keeps both information.

Changes in kpse_search.lua:
* if no extension is included in search string, automatically add one
* return three entries per line: filename / extensions / found target

Changes in preflight (__init__.py):
* extract extensions -> string conversion into IncludeSpec method
* deal with different format of kpse_search.lua return

Added:
* unittest