### PR TITLE
[SSF-109] Parse also files with .pdf_tex extensions (svg.sty generated)

### DIFF
--- a/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
@@ -786,7 +786,8 @@ _extss = _merge(_extss, IMAGE_EXTENSIONS["luatex"].split())
 ALL_IMAGE_EXTS: str = " ".join(_extss)
 
 # only parse file with these extensions
-PARSED_FILE_EXTENSIONS = [".tex", ".sty", ".ltx", ".cls", ".clo"]
+# .pdf_tex are generated tex files from the svg.sty packages
+PARSED_FILE_EXTENSIONS = [".tex", ".sty", ".ltx", ".cls", ".clo", ".pdf_tex"]
 
 single_argument_include_commands = [
     "include",


### PR DESCRIPTION
These files are artifacts generated by svg.sty and need to be parsed so that
the included .pdf file is detected as being used.