### PR TITLE
More consistent error handling / return values

### DIFF
--- a/tex2pdf-service/poetry.lock
+++ b/tex2pdf-service/poetry.lock
@@ -41,7 +41,6 @@ files = []
 develop = false
 
 [package.dependencies]
-chardet = "^5.0"
 pydantic = "^2.8.2"
 ruamel-yaml = "^0.18.5"
 toml = "^0.10.2"
@@ -51,7 +50,7 @@ tomli_w = "^1.0"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "HEAD"
-resolved_reference = "99d5ea8a887dd1a8e2a881e8e72aa8568b3e82b7"
+resolved_reference = "1a269ba5114104b5eb4437a445e784b5380c1c10"
 subdirectory = "tex2pdf-tools"
 
 [[package]]
@@ -74,17 +73,6 @@ python-versions = ">=3.6"
 files = [
     {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
     {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
-]
-
-[[package]]
-name = "chardet"
-version = "5.2.0"
-description = "Universal encoding detector for Python 3"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
-    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
 ]
 
 [[package]]

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -14,7 +14,7 @@ from enum import Enum
 
 from tex2pdf_tools.preflight import PreflightStatusValues, generate_preflight_response
 from tex2pdf_tools.tex_inspection import find_unused_toplevel_files, maybe_bbl
-from tex2pdf_tools.zerozeroreadme import FileUsageType, ZeroZeroReadMe, ZZRMKeyError
+from tex2pdf_tools.zerozeroreadme import FileUsageType, ZeroZeroReadMe, ZZRMKeyError, ZZRMInvalidFormatError
 
 from . import (
     ID_TAG,
@@ -163,12 +163,9 @@ class ConverterDriver:
         self.t0 = time.perf_counter()
 
         self._unpack_tarball()
-        try:
-            self.zzrm = ZeroZeroReadMe(self.in_dir)
-        except ZZRMKeyError:
-            self.zzrm = ZeroZeroReadMe(None)
-            logger.warning("Input directory %s contains an invalid 00README file, and ignored", self.in_dir)
-            pass
+        # this might raise various exceptions, that should be reported to the API down the line
+        self.zzrm = ZeroZeroReadMe(self.in_dir)
+
         self.outcome = {
             ID_TAG: self.tag,
             "status": None,


### PR DESCRIPTION
Don't catch error messages when loading zzrm files, but catch them on the
api level and return a proper 500 response with stacktrace.