### PR TITLE
ZZRM fix bug where toplevel files got lost

### DIFF
--- a/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
@@ -267,7 +267,7 @@ class ZeroZeroReadMe:
             if len(idioms) == 2:
                 filename = idioms[0]
                 keyword = idioms[1]
-                userfile: UserFile = UserFile(filename=filename)
+                userfile: UserFile = self.sources[filename] if filename in self.sources else UserFile(filename=filename)
                 # go over the possible entries in v1 00README files
                 #   file toplevelfile
                 #   file ignored


### PR DESCRIPTION
In case we have multiple statements for the same file, all the previous ones got lost. e.g.
	foo.tex	toplevelfile
	foo.tex landscape
then we would only record the landscape but not the toplevelfile information.

This is actually a "useless" specification, since landscape only applies to .dvi files, but it can be done and is syntactically correct.

Make sure we update the same structure.