### PR TITLE
Old-style ZZRM include does **not** mean that we append it!

### DIFF
--- a/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
@@ -548,8 +548,6 @@ class ZeroZeroReadMe:
             if uf.usage == FileUsageType.toplevel:
                 # convert .tex to .pdf filename
                 assembly.append(strip_to_basename(fn, ".pdf"))
-            elif uf.usage == FileUsageType.include:
-                assembly.append(fn)
         return assembly
 
     def to_yaml(self, output: typing.TextIO) -> typing.TextIO:


### PR DESCRIPTION
Mis-interpretation of mine, fix it by removing it from the assembly list.