### PR TITLE
ARXIVCE-3451: Include index files in directives summary plus other enhancements and fixes.

### DIFF
--- a/tex2pdf-tools/tests/directives/fixture/index_files/gcp_preflight.json
+++ b/tex2pdf-tools/tests/directives/fixture/index_files/gcp_preflight.json
@@ -1,0 +1,57 @@
+{
+  "status": {
+    "key": "success"
+  },
+  "detected_toplevel_files": [
+    {
+      "filename": "solvable.tex",
+      "process": {
+        "compiler": {
+          "engine": "tex",
+          "lang": "latex",
+          "output": "pdf",
+          "postp": "none"
+        },
+        "bibliography": {
+          "pre_generated": true
+        },
+        "index": {
+          "pre_generated": true
+        }
+      },
+      "hyperref_found": true,
+      "issues": [
+        {
+          "key": "issue_in_subfile",
+          "info": "1",
+          "filename": "solvable.tex"
+        }
+      ]
+    }
+  ],
+  "tex_files": [
+    {
+      "filename": "solvable.tex",
+      "language": "latex",
+      "contains_documentclass": true,
+      "hyperref_found": true,
+      "used_idx_files": [
+        "solvable.idx"
+      ],
+      "used_ind_files": [
+        "solvable.ind"
+      ],
+      "used_other_files": [
+        "solvable.bbl"
+      ],
+      "issues": [
+        {
+          "key": "file_not_found",
+          "info": "cft.bib"
+        }
+      ]
+    }
+  ],
+  "ancillary_files": [],
+  "maybe_used_files": []
+}

--- a/tex2pdf-tools/tests/directives/test_directives.py
+++ b/tex2pdf-tools/tests/directives/test_directives.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import json
 from unittest.mock import MagicMock, patch
 from tex2pdf_tools.directives import DirectiveManager
 
@@ -232,6 +233,44 @@ class TestDirectiveManager(unittest.TestCase):
         mock_listdir.return_value = ['00README.XXX']
         manager = DirectiveManager("dummy_dir")
         self.assertFalse(manager.v2_exists())
+
+    def setUp(self):
+        self.fixture_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "fixture"))
+
+    def test_used_index_files(self) -> None:
+        """Test detection of used index files."""
+        dir_path = os.path.join(self.fixture_dir, "index_files")
+
+        preflight_file = os.path.join(dir_path, 'gcp_preflight.json')
+        src_dir = os.path.join(dir_path, 'src')
+        #output_json = <some temporary location that exists during tests>
+
+        # Read the preflight JSON file and check specific fields
+        with open(preflight_file, 'r') as f:
+            preflight_json = json.load(f)
+            tex_files = preflight_json.get("tex_files", [])
+            # Note: "solvable.idx" exists in preflight but not in src directory
+            self.assertTrue(any("solvable.idx" in file.get("used_idx_files", []) for file in tex_files))
+            self.assertTrue(any("solvable.ind" in file.get("used_ind_files", []) for file in tex_files))
+
+        # put together arguments and call
+
+        # Create
+        manager = DirectiveManager(dir_path)
+        directives = {}
+        serial = manager.process_directives()
+        directives["directives"] = serial
+        preflight_data = manager.load_preflight_data(preflight_file)
+        directives["preflight"] = preflight_data
+
+        # For manual inspection
+        with open('/tmp/test_output.json', "w") as outfile:
+            json.dump(directives, outfile, indent=2)
+
+        # Inspect the JSON output for specific field values
+        self.assertIn("used_files", directives["preflight"])
+        self.assertIn("solvable.ind", directives["preflight"]["used_files"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tex2pdf-tools/tests/directives/test_directives.py
+++ b/tex2pdf-tools/tests/directives/test_directives.py
@@ -242,7 +242,9 @@ class TestDirectiveManager(unittest.TestCase):
         dir_path = os.path.join(self.fixture_dir, "index_files")
 
         preflight_file = os.path.join(dir_path, 'gcp_preflight.json')
-        src_dir = os.path.join(dir_path, 'src')
+        # src_dir is not required for this test, but the module checks that
+        # a src_dif exists
+        src_dir = preflight_file
         #output_json = <some temporary location that exists during tests>
 
         # Read the preflight JSON file and check specific fields
@@ -256,7 +258,7 @@ class TestDirectiveManager(unittest.TestCase):
         # put together arguments and call
 
         # Create
-        manager = DirectiveManager(dir_path)
+        manager = DirectiveManager(dir_path, src_dir)
         directives = {}
         serial = manager.process_directives()
         directives["directives"] = serial

--- a/tex2pdf-tools/tests/directives/test_directives.py
+++ b/tex2pdf-tools/tests/directives/test_directives.py
@@ -244,7 +244,7 @@ class TestDirectiveManager(unittest.TestCase):
         preflight_file = os.path.join(dir_path, 'gcp_preflight.json')
         # src_dir is not required for this test, but the module checks that
         # a src_dif exists
-        src_dir = preflight_file
+        src_dir = dir_path
         #output_json = <some temporary location that exists during tests>
 
         # Read the preflight JSON file and check specific fields

--- a/tex2pdf-tools/tex2pdf_tools/directives/__main__.py
+++ b/tex2pdf-tools/tex2pdf_tools/directives/__main__.py
@@ -214,7 +214,7 @@ def main():
         with open(args.output_file, "w") as outfile:
             json.dump(directives, outfile, indent=2)
 
-    if args.base and args.identifier:
+    elif args.base and args.identifier:
         base_submission_dir = os.path.join(args.base, args.identifier[:4], args.identifier)
         if os.path.exists(base_submission_dir):
             new_filename = "directives.json"

--- a/tex2pdf-tools/tex2pdf_tools/directives/__main__.py
+++ b/tex2pdf-tools/tex2pdf_tools/directives/__main__.py
@@ -69,7 +69,14 @@ def main():
     if args.base and args.base is not DEFAULT_BASE and args.root_dir:
         parser.error("Arguments --base_dir and --root_dir cannot be used together.")
 
-    if not args.root_dir and args.base and not os.path.exists(args.base):
+    if args.root_dir and not os.path.exists(args.root_dir):
+        parser.error(
+            f"Arguments root directory does not exist {args.root_dir}"
+        )
+
+    if not args.root_dir and args.base and not os.path.exists(args.base)\
+            and not (args.preflight_file and args.src_dir):
+        # Allow override when both preflight file and src directory are specified.
         parser.error(
             f"Arguments base directory does not exist {args.base}: Use --root_dir or both --base and --identifier."
         )

--- a/tex2pdf-tools/tex2pdf_tools/directives/__main__.py
+++ b/tex2pdf-tools/tex2pdf_tools/directives/__main__.py
@@ -213,7 +213,6 @@ def main():
     preflight_data = manager.load_preflight_data(args.preflight_file)
     #    directives['ignore'] = node
     directives["preflight"] = preflight_data
-    directives["preflight"] = preflight_data
 
     # Direct output to specified output file, otherwise use standard
     # submission directory (if available) to store

--- a/tex2pdf-tools/tex2pdf_tools/preflight/report.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/report.py
@@ -70,6 +70,10 @@ class PreflightReport:
                                 collected_files.update(tex_file["used_other_files"])
                             if "used_bib_files" in tex_file:
                                 collected_files.update(tex_file["used_bib_files"])
+                            if "used_idx_files" in tex_file:
+                                collected_files.update(tex_file["used_idx_files"])
+                            if "used_ind_files" in tex_file:
+                                collected_files.update(tex_file["used_ind_files"])
             return collected_files
 
         visited: set[str] = set()
@@ -103,6 +107,14 @@ class PreflightReport:
                                 used_files.add(child_filename)
                         if "used_bib_files" in tex_file:
                             for child_filename in tex_file["used_bib_files"]:
+                                node[filename]["children"].append({child_filename: {"issues": [], "children": []}})
+                                used_files.add(child_filename)
+                        if "used_ind_files" in tex_file:
+                            for child_filename in tex_file["used_ind_files"]:
+                                node[filename]["children"].append({child_filename: {"issues": [], "children": []}})
+                                used_files.add(child_filename)
+                        if "used_inx_files" in tex_file:
+                            for child_filename in tex_file["used_inx_files"]:
                                 node[filename]["children"].append({child_filename: {"issues": [], "children": []}})
                                 used_files.add(child_filename)
             return node

--- a/tex2pdf-tools/tex2pdf_tools/preflight/report.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/report.py
@@ -113,8 +113,8 @@ class PreflightReport:
                             for child_filename in tex_file["used_ind_files"]:
                                 node[filename]["children"].append({child_filename: {"issues": [], "children": []}})
                                 used_files.add(child_filename)
-                        if "used_inx_files" in tex_file:
-                            for child_filename in tex_file["used_inx_files"]:
+                        if "used_idx_files" in tex_file:
+                            for child_filename in tex_file["used_idx_files"]:
                                 node[filename]["children"].append({child_filename: {"issues": [], "children": []}})
                                 used_files.add(child_filename)
             return node


### PR DESCRIPTION
This PR addresses the issue where index files are incorrectly marked for deletion instead of being indicated as 'used' on the Review Files page. These changes integrate the recent additions related to index files in the preflight report into the directives summary report that is passed to the UI.

There are several other minor fixes included in this PR.

This code is deployed on dev4.

![Screenshot 2025-04-09 at 8 51 25 AM](https://github.com/user-attachments/assets/f8797bf4-89ac-4cc3-a3e3-8d57ac9aacd3)
