### PR TITLE
[minor] encode bbl_version to pretty-print without b marker

### DIFF
--- a/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
@@ -1591,10 +1591,11 @@ def deal_with_bibliographies(
                 if head[1].startswith(b"% $ biblatex bbl format version "):
                     bbl_version = head[1].removeprefix(b"% $ biblatex bbl format version ").removesuffix(b" $")
                     if bbl_version != CURRENT_ARXIV_TEX_BBL_VERSION.encode("ascii"):
+                        bbl_version_utf8 = bbl_version.decode("utf-8")
                         node.issues.append(
                             TeXFileIssue(
                                 IssueType.bbl_version_mismatch,
-                                f"Expected {CURRENT_ARXIV_TEX_BBL_VERSION} but got {bbl_version!r}",
+                                f"Expected {CURRENT_ARXIV_TEX_BBL_VERSION} but got {bbl_version_utf8}",
                                 bbl_file,
                             )
                         )


### PR DESCRIPTION
Cleaning up one print to not include the `b''` marker.

![image](https://github.com/user-attachments/assets/6b8390af-65dd-4d2b-8077-03fde2730982)
