### PR TITLE
[tex2pdf service] make validation and http exceptions into 400 errors

### DIFF
--- a/tex2pdf-service/tex2pdf/tex2pdf_api.py
+++ b/tex2pdf-service/tex2pdf/tex2pdf_api.py
@@ -10,9 +10,12 @@ import typing
 
 from fastapi import FastAPI, Query, UploadFile
 from fastapi import status as STATCODE
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.requests import Request
 from starlette.responses import FileResponse, HTMLResponse
 
 from . import MAX_APPENDING_FILES, MAX_TIME_BUDGET, MAX_TOPLEVEL_TEX_FILES, USE_ADDON_TREE
@@ -57,6 +60,19 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# make it more obious if a validation error happened
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+    return JSONResponse(
+        status_code=STATCODE.HTTP_400_BAD_REQUEST, content={"message": "HTTP exception: " + str(exc.detail)}
+    )
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    return JSONResponse(
+        status_code=STATCODE.HTTP_400_BAD_REQUEST, content={"message": "Invalid request format: " + str(exc)}
+    )
 
 
 class Message(BaseModel):


### PR DESCRIPTION
FastAPI returns 422 errors on validation failures and http exceptions.
Add  a handler for those exceptions to add some informal message what has happened.