### PR TITLE
Increase gs run timeout and better reporting

### DIFF
--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -478,6 +478,10 @@ class ConverterDriver:
 
         if self.water.text and (not self.zzrm.nostamp):
             pdf_file = os.path.join(self.out_dir, outcome["pdf_file"])
+            # the "combine documents" step may have failed, and the pdf_file may not exist
+            if not os.path.exists(pdf_file):
+                logger.warning("PDF file %s not found, cannot watermark", pdf_file, extra=self.log_extra)
+                return
             temp_name = outcome["pdf_file"] + ".watermarked.pdf"
             watered = self._watermark(pdf_file, os.path.join(self.out_dir, temp_name))
 

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -462,7 +462,7 @@ class ConverterDriver:
             pass
         except Exception as exc:
             if isinstance(exc, (subprocess.TimeoutExpired, subprocess.CalledProcessError)):
-                logger.warning("Failed combining PDFs: %s", exc, extra=self.log_extra)
+                logger.warning("Failed combining PDFs: %s (stdout=%s, stderr=%s)", exc, exc.stdout, exc.stderr, extra=self.log_extra)
                 outcome["gs"] = {}
                 if isinstance(exc, subprocess.CalledProcessError):
                     outcome["gs"]["return_code"] = exc.returncode

--- a/tex2pdf-service/tex2pdf/doc_converter.py
+++ b/tex2pdf-service/tex2pdf/doc_converter.py
@@ -103,7 +103,7 @@ def combine_documents(
     ] + effective_pdf_list
     logger.debug("Running gs to combine pdfs: %s", shlex.join(gs_cmd), extra=log_extra)
     # exception handing is done in convert_driver:_finalize_pdf
-    ret = subprocess.run(gs_cmd, capture_output=True, timeout=30, check=True, text=True)
+    ret = subprocess.run(gs_cmd, capture_output=True, timeout=60, check=True, text=True)
     addon_outcome["gs"] = {}
     addon_outcome["gs"]["stdout"] = ret.stdout
     addon_outcome["gs"]["stderr"] = ret.stderr


### PR DESCRIPTION
Changes around combining documents and followup:

* we have seen timeouts in combining documents on tex2pdf, increase the timeout from 30sec to 60sec
* log stdout and stderr if a timeout or call exception happened
* only try to run watermarking code when the source pdf was created - in case of gs timeouts it wouldn't