### PR TITLE
Revert threading changes - bump pdftk timeout to 120sec

### DIFF
--- a/tex2pdf-service/tex2pdf/doc_converter.py
+++ b/tex2pdf-service/tex2pdf/doc_converter.py
@@ -4,9 +4,6 @@ import os
 import shlex
 import shutil
 import subprocess
-import threading
-import time
-from typing import IO
 
 from PIL import Image, UnidentifiedImageError
 
@@ -32,104 +29,6 @@ def strip_to_basename(path_list: list[str], extent: None | str = None) -> list[s
     if extent is None:
         return [os.path.basename(path) for path in path_list]
     return [os.path.splitext(os.path.basename(path))[0] + extent for path in path_list]
-
-
-def read_stream_continuously(stream: IO[str], output_list: list[str], stop_event: threading.Event) -> None:
-    """Read a given stream (stdout or stderr) continuously and appends lines to a list."""
-    logger = get_logger()
-    for line in iter(stream.readline, ""):
-        if stop_event.is_set():
-            break
-        logger.debug(line)
-        output_list.append(line.strip())
-    stream.close()
-
-
-def run_subprocess_with_timeout(command: list[str], timeout_seconds: int = 60) -> tuple[list[str], list[str], int]:
-    """
-    Start a subprocess with a timeout, read and report stdout/stderr continously.
-
-    Starts a subprocess, reads its stdout and stderr continuously,
-    ensures it does not run longer than the specified timeout, and
-    returns all collected stdout and stderr.
-    """
-    logger = get_logger()
-    logger.info(f"Attempting to run command: {' '.join(command)}")
-    logger.info(f"Timeout set to: {timeout_seconds} seconds")
-
-    process = None
-    stdout_thread = None
-    stderr_thread = None
-    stop_event = threading.Event()
-
-    collected_stdout: list[str] = []
-    collected_stderr: list[str] = []
-    return_code = None
-
-    try:
-        # Start the subprocess
-        # stderr=subprocess.PIPE to capture stderr separately
-        process = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,  # Capture stderr separately
-            text=True,
-        )
-
-        # Start a thread to read stdout continuously
-        stdout_thread = threading.Thread(
-            target=read_stream_continuously, args=(process.stdout, collected_stdout, stop_event)
-        )
-        stdout_thread.daemon = True
-        stdout_thread.start()
-
-        # Start a thread to read stderr continuously
-        stderr_thread = threading.Thread(
-            target=read_stream_continuously, args=(process.stderr, collected_stderr, stop_event)
-        )
-        stderr_thread.daemon = True
-        stderr_thread.start()
-
-        start_time = time.time()
-        while process.poll() is None:
-            if time.time() - start_time > timeout_seconds:
-                print(f"\nTimeout of {timeout_seconds} seconds reached. Terminating subprocess.")
-                process.terminate()
-                time.sleep(0.1)
-                if process.poll() is None:
-                    print("Subprocess did not terminate gracefully, killing it.")
-                    process.kill()
-                break
-            time.sleep(0.1)
-
-        # Signal threads to stop and wait for them to finish reading
-        stop_event.set()
-        if stdout_thread.is_alive():
-            stdout_thread.join(timeout=5)
-        if stderr_thread.is_alive():
-            stderr_thread.join(timeout=5)
-
-        # Wait for the subprocess to officially terminate and get its return code
-        return_code = process.wait()
-        print(f"\nSubprocess finished with return code: {return_code}")
-
-    except FileNotFoundError:
-        logger.error(f"Error: Command '{command[0]}' not found. Please ensure it's in your PATH.")
-        return_code = 127  # Common exit code for command not found
-        collected_stderr.append(f"Error: Command '{command[0]}' not found.")
-    except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
-        collected_stderr.append(f"An unexpected error occurred: {e}")
-        return_code = 1  # Generic error code
-    finally:
-        if process and process.poll() is None:
-            logger.warning("Ensuring subprocess is terminated in finally block.")
-            process.terminate()
-            process.wait(timeout=5)
-            if process.poll() is None:
-                process.kill()
-
-    return collected_stdout, collected_stderr, return_code
 
 
 def combine_documents(
@@ -207,21 +106,21 @@ def combine_documents(
         "cat",
         "output",
         output_path,
-        "verbose",
     ]
     logger.debug("Running gs to combine pdfs: %s", shlex.join(gs_cmd), extra=log_extra)
-    out, err, ret = run_subprocess_with_timeout(gs_cmd, timeout_seconds=60)
-    if ret != 0:
-        logger.error("gs command failed with return code %d", ret, extra=log_extra)
-        # if gs fails, we try pdftk
-        logger.warning("Trying pdftk to combine pdfs as gs failed.", extra=log_extra)
+    # exception handing is done in convert_driver:_finalize_pdf
+    try:
+        ret = subprocess.run(gs_cmd, capture_output=True, timeout=60, check=True, text=True)
+    except subprocess.TimeoutExpired as e:
+        logger.warning("gs command timed out, trying pdftk: %s", e, extra=log_extra)
         logger.debug("Running pdftk to combine pdfs: %s", shlex.join(pdftk_cmd), extra=log_extra)
-        out, err, ret = run_subprocess_with_timeout(pdftk_cmd, timeout_seconds=60)
-        if ret != 0:
-            logger.error("pdftk command failed with return code %d", ret, extra=log_extra)
-            raise Exception(f"Failed to combine documents: {err}")
+        try:
+            ret = subprocess.run(pdftk_cmd, capture_output=True, timeout=60, check=True, text=True)
+        except subprocess.TimeoutExpired as e2:
+            logger.error("pdftk command timed out: %s", e2, extra=log_extra)
+            raise
     addon_outcome["gs"] = {}
-    addon_outcome["gs"]["stdout"] = out
-    addon_outcome["gs"]["stderr"] = err
-    addon_outcome["gs"]["return_code"] = ret
+    addon_outcome["gs"]["stdout"] = ret.stdout
+    addon_outcome["gs"]["stderr"] = ret.stderr
+    addon_outcome["gs"]["return_code"] = ret.returncode
     return out_filename, strip_to_basename(converted_docs), strip_to_basename(failed_docs), addon_outcome

--- a/tex2pdf-service/tex2pdf/doc_converter.py
+++ b/tex2pdf-service/tex2pdf/doc_converter.py
@@ -115,7 +115,7 @@ def combine_documents(
         logger.warning("gs command timed out, trying pdftk: %s", e, extra=log_extra)
         logger.debug("Running pdftk to combine pdfs: %s", shlex.join(pdftk_cmd), extra=log_extra)
         try:
-            ret = subprocess.run(pdftk_cmd, capture_output=True, timeout=60, check=True, text=True)
+            ret = subprocess.run(pdftk_cmd, capture_output=True, timeout=120, check=True, text=True)
         except subprocess.TimeoutExpired as e2:
             logger.error("pdftk command timed out: %s", e2, extra=log_extra)
             raise


### PR DESCRIPTION
Revert debugging changes introducing threads

Also bump pdftk timeout to 120sec, as it has the highest chance to terminate in time.