### PR TITLE
[ARXIVCE-3712] [preflight] improve bibtex/biber/bbl detection logic

### DIFF
--- a/tex2pdf-tools/tests/preflight/fixture/biblatex-bibliography/main.bbl
+++ b/tex2pdf-tools/tests/preflight/fixture/biblatex-bibliography/main.bbl
@@ -1,0 +1,46 @@
+% $ biblatex auxiliary file $
+% $ biblatex bbl format version 3.2 $
+% Do not modify the above lines!
+%
+% This is an auxiliary file used by the 'biblatex' package.
+% This file may safely be deleted. It will be recreated by
+% biber as required.
+%
+\begingroup
+\makeatletter
+\@ifundefined{ver@biblatex.sty}
+  {\@latex@error
+     {Missing 'biblatex' package}
+     {The bibliography requires the 'biblatex' package.}
+      \aftergroup\endinput}
+  {}
+\endgroup
+
+
+\refsection{0}
+  \datalist[entry]{nty/global//global/global}
+    \entry{abc}{misc}{}
+      \name{author}{1}{}{%
+        {{hash=aaec8f7cde1b31eaf9a852e971919860}{%
+           family={Someone},
+           familyi={S\bibinitperiod}}}%
+      }
+      \strng{namehash}{aaec8f7cde1b31eaf9a852e971919860}
+      \strng{fullhash}{aaec8f7cde1b31eaf9a852e971919860}
+      \strng{bibnamehash}{aaec8f7cde1b31eaf9a852e971919860}
+      \strng{authorbibnamehash}{aaec8f7cde1b31eaf9a852e971919860}
+      \strng{authornamehash}{aaec8f7cde1b31eaf9a852e971919860}
+      \strng{authorfullhash}{aaec8f7cde1b31eaf9a852e971919860}
+      \field{sortinit}{S}
+      \field{sortinithash}{b164b07b29984b41daf1e85279fbc5ab}
+      \field{labelnamesource}{author}
+      \field{labeltitlesource}{title}
+      \field{howpublished}{It got published!}
+      \field{note}{Betelgeuse}
+      \field{title}{Some Title}
+      \field{year}{2025}
+    \endentry
+  \enddatalist
+\endrefsection
+\endinput
+

--- a/tex2pdf-tools/tests/preflight/fixture/biblatex-bibliography/main.tex
+++ b/tex2pdf-tools/tests/preflight/fixture/biblatex-bibliography/main.tex
@@ -1,0 +1,7 @@
+\documentclass{article} 
+\usepackage{biblatex}
+\bibliography{xxx.bib}
+\begin{document}
+Hello World\cite{abc} Bye Bye.
+\printbibliography
+\end{document}

--- a/tex2pdf-tools/tests/preflight/fixture/biblatex-bibliography/xxx.bib
+++ b/tex2pdf-tools/tests/preflight/fixture/biblatex-bibliography/xxx.bib
@@ -1,0 +1,7 @@
+@MISC{abc,
+  author = "Someone",
+  title = {Some Title},
+  howpublished = {It got published!},
+  year = {2025},
+  note = {Betelgeuse}
+}

--- a/tex2pdf-tools/tests/preflight/test_preflight.py
+++ b/tex2pdf-tools/tests/preflight/test_preflight.py
@@ -505,6 +505,20 @@ class TestPreflight(unittest.TestCase):
         self.assertEqual(tf.used_bib_files, ["xxx.bib", "xxx.bib"])
         self.assertEqual(tf.used_other_files, [])
 
+    def test_biblatex_with_bibliography(self):
+        """Test submission with using biblatex and \bibliography."""
+        dir_path = os.path.join(self.fixture_dir, "biblatex-bibliography")
+        pf: PreflightResponse = generate_preflight_response(dir_path)
+        self.assertEqual(pf.status.key.value, "success")
+        self.assertEqual(len(pf.detected_toplevel_files), 1)
+        tf = pf.detected_toplevel_files[0]
+        self.assertEqual(len(tf.issues), 0)
+        self.assertEqual(len(pf.tex_files), 1)
+        tf = pf.tex_files[0]
+        self.assertEqual(len(tf.issues), 0)
+        self.assertEqual(tf.used_bib_files, ["xxx.bib"])
+        self.assertEqual(tf.used_other_files, ["main.bbl"])
+
     def test_double_slash_normalization(self):
         """Test double slash normalization present."""
         dir_path = os.path.join(self.fixture_dir, "double-slash-normalization")


### PR DESCRIPTION
we mixed up two items:
* the postprocessor used (biber, bibtex, ...)
* the file format for the bbl file (plain, biblatex)

Thus, we got errors when a document used
	\usepackage{biblatex}
	\bibliography{foo}
since it was detected as both biber and bibtex.

The correct way is to detect the bbl file type (either plain or biblatex) and track that separately.