### PR TITLE
[ARXIVCE-3751] [service] ensure that TEXMFVAR points to a submission-local directory

### DIFF
--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -233,6 +233,8 @@ class ConverterDriver:
                 else:
                     logger.debug("Renaming anc directory %s to %s", ancdir, target)
                     os.rename(ancdir, target)
+        # ensure that TEXMFVAR is always a new clean directory
+        os.environ["TEXMFVAR"] = f"{self.work_dir}/texmf-var"
         try:
             # run TeX under try and have a finally to rename the anc directory back
             # in case some exception happens in the TeX processing
@@ -242,6 +244,9 @@ class ConverterDriver:
             self.outcome["reason"] = str(e)
             self.outcome["in_files"] = file_props_in_dir(self.in_dir)
         finally:
+            # revert the TEXMFVAR to the unset value
+            del os.environ["TEXMFVAR"]
+            # deal with the anc directory reverting
             if self.hide_anc_dir and target is not None:
                 logger.debug("Renaming backup anc directory %s back to %s", target, ancdir)
                 os.rename(target, ancdir)

--- a/tex2pdf-service/tex2pdf/tex_to_pdf_converters.py
+++ b/tex2pdf-service/tex2pdf/tex_to_pdf_converters.py
@@ -236,7 +236,9 @@ class BaseConverter:
             "half_error_line": "238",
         }
         # support SOURCE_DATE_EPOCH and FORCE_SOURCE_DATE set in the environment
-        for senv in ["SOURCE_DATE_EPOCH", "FORCE_SOURCE_DATE"]:
+        # also make sure we forward TEXMFVAR settings which are set to a session
+        # specific directory
+        for senv in ["SOURCE_DATE_EPOCH", "FORCE_SOURCE_DATE", "TEXMFVAR"]:
             if os.getenv(senv):
                 cmdenv[senv] = os.getenv(senv, "")  # the "" is only here to placate mypy :-(
         # try detecting incompatible bbl version and adjust TEXMFAUXTREES to make it compile


### PR DESCRIPTION
We have seen problems with incorrectly generated files in a shared TEXMFVAR,
so set TEXMFVAR to a conversion specific directory.

This ensures that left-overs from other runs don't interfere with new submissions,
but also extends the compilation time since some fonts might be regenerated
again and again.

- set it in the converter driver to work-dir/texmf-var
- ensure that it is exported into the env of the actual compilation process