### PR TITLE
Speed up docker builds

### DIFF
--- a/tex2pdf-service/Appliance.Dockerfile
+++ b/tex2pdf-service/Appliance.Dockerfile
@@ -30,14 +30,17 @@ COPY texlive/common/texmf.cnf /usr/local/texlive/${TEXLIVE_BASE_RELEASE}/
 RUN useradd -m -d $WORKER_HOME -s /bin/bash -g users -u 1000 worker
 USER worker
 WORKDIR $WORKER_HOME
-COPY tex2pdf/ ./tex2pdf/
 COPY poetry.lock pyproject.toml ./
 # poetry is BROKEN wrt to installing multiple packages from same git repo
 # see https://github.com/python-poetry/poetry/issues/6958
 # RUN poetry config installer.parallel false
 # install runtime deps - uses $POETRY_VIRTUALENVS_IN_PROJECT internally
-RUN poetry install --without=dev
+RUN poetry install --no-root --without=dev
 
+# copy this afterwards to avoid re-installing poetry deps on each docker build
+COPY tex2pdf/ ./tex2pdf/
+# second poetry run should only install the current project
+RUN poetry install --without=dev
 
 # application specific changes
 ENV PYTHONPATH=$WORKER_HOME


### PR DESCRIPTION
install first the dependencies, then add the tex2pdf dir, and then install only the current package.
That way, the installation of dependencies is cached in docker.