### PR TITLE
[preflight] add sub-types of unsupported_compiler_type

### DIFF
--- a/tex2pdf-tools/tests/preflight/test_preflight.py
+++ b/tex2pdf-tools/tests/preflight/test_preflight.py
@@ -282,7 +282,7 @@ class TestPreflight(unittest.TestCase):
         self.assertTrue(pf.detected_toplevel_files[0].process.compiler is None)
         self.assertEqual(
             pf.detected_toplevel_files[0].issues[0].key,
-            "unsupported_compiler_type"
+            IssueType.unsupported_compiler_type_image_mix
         )
 
     def test_multi_include_cmds(self):
@@ -648,7 +648,7 @@ class TestPreflight(unittest.TestCase):
         self.assertEqual(len(pf.detected_toplevel_files), 1)
         tf = pf.detected_toplevel_files[0]
         self.assertEqual(len(tf.issues), 1)
-        self.assertEqual(tf.issues[0].key, IssueType.unsupported_compiler_type)
+        self.assertEqual(tf.issues[0].key, IssueType.unsupported_compiler_type_latex209)
 
 
     def test_amstex_documentstyle(self):
@@ -676,4 +676,4 @@ class TestPreflight(unittest.TestCase):
             tf = pf.detected_toplevel_files[0]
             self.assertEqual(len(tf.issues), 1)
             issue = tf.issues[0]
-            self.assertEqual(issue.key, IssueType.unsupported_compiler_type)
+            self.assertEqual(issue.key, IssueType.unsupported_compiler_type_unicode)

--- a/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
@@ -393,6 +393,9 @@ class IssueType(str, Enum):
     conflicting_engine_type = "conflicting_engine_type"
     conflicting_postprocess_type = "conflicting_postprocess_type"
     unsupported_compiler_type = "unsupported_compiler_type"
+    unsupported_compiler_type_unicode = "unsupported_compiler_type_unicode"
+    unsupported_compiler_type_image_mix = "unsupported_compiler_type_image_mix"
+    unsupported_compiler_type_latex209 = "unsupported_compiler_type_latex209"
     conflicting_image_types = "conflicting_image_types"
     include_command_with_macro = "include_command_with_macro"
     contents_decode_error = "contents_decode_error"
@@ -1569,7 +1572,9 @@ def guess_compilation_parameters(toplevel_files: dict[str, ToplevelFile], nodes:
                 logging.debug("guess_compilation_parameters: found amstex load, allowing for latex209")
                 found_language = LanguageType.tex
             else:
-                issues.append(TeXFileIssue(IssueType.unsupported_compiler_type, "LaTeX 2.09 is not supported anymore"))
+                issues.append(
+                    TeXFileIssue(IssueType.unsupported_compiler_type_latex209, "LaTeX 2.09 is not supported anymore")
+                )
 
         logging.debug("guess_compilation_parameters: found language %s", found_language)
 
@@ -1668,14 +1673,14 @@ def guess_compilation_parameters(toplevel_files: dict[str, ToplevelFile], nodes:
             if is_unicode_tex:
                 issues.append(
                     TeXFileIssue(
-                        IssueType.unsupported_compiler_type,
+                        IssueType.unsupported_compiler_type_unicode,
                         "Unicode TeX engine (XeTeX or LuaTeX) is required, but currently not supported.",
                     )
                 )
             else:
                 issues.append(
                     TeXFileIssue(
-                        IssueType.unsupported_compiler_type,
+                        IssueType.unsupported_compiler_type_image_mix,
                         "Probable mix of eps and png/jpg/pdf images, which is currently not supported.",
                     )
                 )


### PR DESCRIPTION
New:
* unsupported_compiler_type_latex209
* unsupported_compiler_type_image_mix
* unsupported_compiler_type_unicode

The original unsupported_compiler_type remains for cases when we cannot determin any information at all.