### PR TITLE
[preflight] adjust reporting due to bib->bbl support added

### DIFF
--- a/tex2pdf-tools/tests/preflight/fixture/multi-bib-no-bbl/main.tex
+++ b/tex2pdf-tools/tests/preflight/fixture/multi-bib-no-bbl/main.tex
@@ -1,0 +1,6 @@
+\documentclass{article} 
+\begin{document}
+Hello World\cite{abc} Bye Bye.
+\bibliographystyle{plain}
+\bibliography{xxx,yyy}
+\end{document}

--- a/tex2pdf-tools/tests/preflight/fixture/multi-bib-no-bbl/xxx.bib
+++ b/tex2pdf-tools/tests/preflight/fixture/multi-bib-no-bbl/xxx.bib
@@ -1,0 +1,7 @@
+@MISC{abc,
+  author = "Someone",
+  title = {Some Title},
+  howpublished = {It got published!},
+  year = {2025},
+  note = {Betelgeuse}
+}

--- a/tex2pdf-tools/tests/preflight/test_preflight.py
+++ b/tex2pdf-tools/tests/preflight/test_preflight.py
@@ -467,11 +467,33 @@ class TestPreflight(unittest.TestCase):
         self.assertEqual(len(pf.detected_toplevel_files), 1)
         tf = pf.detected_toplevel_files[0]
         self.assertFalse(tf.process.bibliography.pre_generated)
-        self.assertEqual(len(tf.issues), 1)
-        self.assertEqual(tf.issues[0].key, IssueType.bbl_file_missing)
+        # bbl is missing, but we have bib around
+        self.assertEqual(len(tf.issues), 0)
         self.assertEqual(len(pf.tex_files), 1)
         tf = pf.tex_files[0]
         self.assertEqual(len(tf.issues), 0)
+        self.assertEqual(tf.used_bib_files, ["xxx.bib"])
+        self.assertEqual(tf.used_other_files, [])
+
+    def test_multi_bib_no_bbl(self):
+        """Test submission with multiple bib, no bbl, one bib missing."""
+        dir_path = os.path.join(self.fixture_dir, "multi-bib-no-bbl")
+        pf: PreflightResponse = generate_preflight_response(dir_path)
+        self.assertEqual(pf.status.key.value, "success")
+        self.assertEqual(len(pf.detected_toplevel_files), 1)
+        tf = pf.detected_toplevel_files[0]
+        self.assertFalse(tf.process.bibliography.pre_generated)
+        # bbl is missing, but we have bib around
+        self.assertEqual(len(tf.issues), 2)
+        self.assertEqual(
+            sorted([issue.key for issue in tf.issues]),
+            [IssueType.bbl_bib_file_missing, IssueType.issue_in_subfile]
+        )
+        self.assertEqual(len(pf.tex_files), 1)
+        tf = pf.tex_files[0]
+        self.assertEqual(len(tf.issues), 1)
+        self.assertEqual(tf.issues[0].key, IssueType.file_not_found)
+        self.assertEqual(tf.issues[0].filename, "yyy.bib")
         self.assertEqual(tf.used_bib_files, ["xxx.bib"])
         self.assertEqual(tf.used_other_files, [])
 
@@ -483,11 +505,16 @@ class TestPreflight(unittest.TestCase):
         self.assertEqual(len(pf.detected_toplevel_files), 1)
         tf = pf.detected_toplevel_files[0]
         self.assertFalse(tf.process.bibliography.pre_generated)
-        self.assertEqual(len(tf.issues), 1)
-        self.assertEqual(tf.issues[0].key, IssueType.bbl_file_missing)
+        self.assertEqual(len(tf.issues), 2)
+        self.assertEqual(
+            sorted([issue.key for issue in tf.issues]),
+            [IssueType.bbl_bib_file_missing, IssueType.issue_in_subfile]
+        )
         self.assertEqual(len(pf.tex_files), 1)
         tf = pf.tex_files[0]
-        self.assertEqual(len(tf.issues), 0)
+        self.assertEqual(len(tf.issues), 1)
+        self.assertEqual(tf.issues[0].key, IssueType.file_not_found)
+        self.assertEqual(tf.issues[0].filename, "xxx.bib")
         self.assertEqual(tf.used_bib_files, [])
         self.assertEqual(tf.used_other_files, [])
 


### PR DESCRIPTION
* dropped issue "bbl_file_missing"
* added issue "bbl_bib_file_missing" when both bbl and at least one of the used bib files are missing
* Issues are create as follows:
  - bbl file present -> no issues
  - bbl file not present, all bib files present -> no issue
  - bbl file not present, at least one bib file not present -> 
    . add toplevel file issue "bbl_bib_file_missing"
    . add tex file issue "file_not_found" for bib file . add toplevel issue "issues_in_subfile"