### PR TITLE
[ARXIVCE-3858] add missing texlive_version to zzrm to_dict

### DIFF
--- a/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
@@ -176,6 +176,8 @@ class ZeroZeroReadMe:
             result["stamp"] = self.stamp
         if self.nohyperref is not None:
             result["nohyperref"] = self.nohyperref
+        if self.texlive_version is not None:
+            result["texlive_version"] = self.texlive_version
         return result
 
     def init_from_file(self, file: str) -> None:


### PR DESCRIPTION
Needed to reach the UI from a saved 00README.json