### PR TITLE
Convert 'version' to 'spec_version' and add 'comment'

### DIFF
--- a/tex2pdf-tools/tests/zerozeroreadme/fixture/zzrm_comment/00README.json
+++ b/tex2pdf-tools/tests/zerozeroreadme/fixture/zzrm_comment/00README.json
@@ -1,4 +1,5 @@
 {
+  "comment": "This is a genious comment",
   "process": {
     "compiler": "latex",
     "fontmaps": [
@@ -30,6 +31,5 @@
       "filename": "jackson-5.tex"
     }
   ],
-  "stamp": "no",
-  "spec_version":100
+  "stamp": "no"
 }

--- a/tex2pdf-tools/tests/zerozeroreadme/fixture/zzrm_comment_number/00README.json
+++ b/tex2pdf-tools/tests/zerozeroreadme/fixture/zzrm_comment_number/00README.json
@@ -1,4 +1,5 @@
 {
+  "comment": 42,
   "process": {
     "compiler": "latex",
     "fontmaps": [
@@ -30,6 +31,5 @@
       "filename": "jackson-5.tex"
     }
   ],
-  "stamp": "no",
-  "spec_version":100
+  "stamp": "no"
 }


### PR DESCRIPTION
Rename version to spec_version, but keep accepting ZZRM with 'version' set, but ignore its value.

Add 'comment' as new key.

Add unittests for comments and optionally adding default comment.