### PR TITLE
Allow for parallel tl2023,autotex-tl2023 compilation system definition

### DIFF
--- a/tex2pdf-service/poetry.lock
+++ b/tex2pdf-service/poetry.lock
@@ -101,7 +101,7 @@ tomli_w = "*"
 type = "git"
 url = "https://github.com/arXiv/submission-tools.git"
 reference = "HEAD"
-resolved_reference = "096998650d73cd6cf7c5489361df130d5793f41e"
+resolved_reference = "457df53e3990530c476e0d3cb043b46d735707b9"
 subdirectory = "tex2pdf-tools"
 
 [[package]]

--- a/tex2pdf-service/tests/test_docker.py
+++ b/tex2pdf-service/tests/test_docker.py
@@ -211,9 +211,10 @@ def docker_container(request):
             [
                 "--network", "host",
                 "--env",     "TEX2PDF_PROXY_RELEASE=1",
-                "--env",     f"TEX2PDF_SCOPES=tl2023:{TL2023_CUTOFF}",
+                "--env",     f"TEX2PDF_SCOPES=tl2023,autotex-tl2023:{TL2023_CUTOFF}",
                 "--env",     f"TEX2PDF_KEYS_TO_URLS_tl2023=http://localhost:{PORT_2023}/convert/",
                 "--env",     f"TEX2PDF_KEYS_TO_URLS_tl2025=http://localhost:{PORT_2025}/convert/",
+                "--env",     "TEX2PDF_KEYS_TO_URLS_autotex-tl2023=http://localhost:9999/no-such-autotex/",
             ],
         )
         # fmt: on
@@ -258,7 +259,7 @@ def test_api_texlive_version_info(docker_container):
     assert response.status_code == 200
     ret = response.json()
     assert ret["version"] == "2024"
-    assert sorted(ret["proxy_version"]) == ["tl2023", "tl2025"]
+    assert sorted(ret["proxy_version"]) == ["autotex-tl2023", "tl2023", "tl2025"]
 
 
 # this test doesn't work with the remote compilation since the status changes from 500 to 400 ???

--- a/tex2pdf-service/tex2pdf/__init__.py
+++ b/tex2pdf-service/tex2pdf/__init__.py
@@ -54,6 +54,19 @@ if TEX2PDF_PROXY_RELEASE == "1":
         TEX2PDF_SCOPES = os.environ.get("TEX2PDF_SCOPES", "")
     elif PROJECT_NR != 0:
         # defaults
+        # AutoTeX has the following definitions for cutover, which we need to duplicate here
+        #           CUTOVER2023  => 1684778400, # Date::Parse::str2time('2023-05-22T18:00', 'GMT')
+        #           CUTOVER2020  => 1601553600, # Date::Parse::str2time('2020-10-01T12:00', 'GMT')
+        #           CUTOVER2016  => 1486670400, # Date::Parse::str2time('2017-02-09T20:00', 'GMT')
+        #           CUTOVER2011  => 1323129600, # Date::Parse::str2time('2011-12-06', 'GMT')
+        #           CUTOVER2009  => 1262217600, # Date::Parse::str2time('2009-12-31', 'GMT')
+        #           CUTOVER2006  => 1162425600, # Date::Parse::str2time('2006-11-02', 'GMT')
+        #           CUTOVER2004  => 1072915200, # Date::Parse::str2time('2004-01-01', 'GMT')
+        #           CUTOVER2003  => 1041379200, # Date::Parse::str2time('2003-01-01', 'GMT')
+        #           CUTOVER2002  => 1030838400, # Date::Parse::str2time('2002-09-01', 'GMT')
+        # where CUTOVER2002/2003/2004 are all for teTeX2 with different TEXMFCNF files
+        #
+        # for tl2025 default for now we used Date::Parse::str2time('2025-09-15T00:00', 'GMT')
         TEX2PDF_KEYS_TO_URLS = {
             "autotex-te2": f"https://tex2pdf-autotex-te2-{PROJECT_NR}.us-central1.run.app/autotex/",
             "autotex-te3": f"https://tex2pdf-autotex-te3-{PROJECT_NR}.us-central1.run.app/autotex/",
@@ -65,11 +78,6 @@ if TEX2PDF_PROXY_RELEASE == "1":
             "tl2023": f"https://tex-to-pdf-2023-{PROJECT_NR}.us-central1.run.app/convert/",
             "tl2025": f"https://tex-to-pdf-2025-{PROJECT_NR}.us-central1.run.app/convert/",
         }
-        # TODO how to deal with parallel v1 and v1.5 submissions where we have autotex-tl2023 and tl2023?
-        # Idea to be implemented:
-        # - allow for autotex-XXXX and XXXX in the left part of the scope
-        # - check for presence of autotex-XXXX prefix to distinguish between v1 and v1.5 submissions
-        # - we also need a "auto" variant that uses the ZZRM set version!
         DEFAULT_SCOPES = (
             "autotex-te2:1162425600:"
             "autotex-te3:1262217600:"
@@ -77,7 +85,7 @@ if TEX2PDF_PROXY_RELEASE == "1":
             "autotex-tl2011:1486670400:"
             "autotex-tl2016:1601553600:"
             "autotex-tl2020:1684778400:"
-            "autotex-tl2023,tl2023:1767225600:"
+            "autotex-tl2023,tl2023:1757894400:"
             "tl2025"
         )
         TEX2PDF_SCOPES = os.environ.get("TEX2PDF_SCOPES", DEFAULT_SCOPES)

--- a/tex2pdf-service/tex2pdf/__init__.py
+++ b/tex2pdf-service/tex2pdf/__init__.py
@@ -31,22 +31,61 @@ GIT_COMMIT_HASH: str = os.environ.get("GIT_COMMIT_HASH", "(unknown)")
 TEXLIVE_BASE_RELEASE: str = os.environ.get("TEXLIVE_BASE_RELEASE", "")
 AUTOTEX_BRANCH: str = os.environ.get("AUTOTEX_BRANCH", "")
 
+PROJECT_ID: str = os.environ.get("PROJECT_ID", "")
+PROJECT_NR: int = int(os.environ.get("PROJECT_NR", "0"))
+
 # The default TeX Live version to use for compilation
 # Default is empty, so use the current built-in version.
 TEX2PDF_PROXY_RELEASE = os.environ.get("TEX2PDF_PROXY_RELEASE", "0")
-_DEFAULT_TEX2PDF_SCOPES: str = ""
-TEX2PDF_SCOPES: str = _DEFAULT_TEX2PDF_SCOPES
+TEX2PDF_SCOPES: str = ""
 TEX2PDF_KEYS_TO_URLS: dict[str, str] = {}
 # check whether deployment is a proxy deployment
 # only if TEX2PDF_PROXY_RELEASE is set to 1 we allow for proxy setup
 if TEX2PDF_PROXY_RELEASE == "1":
-    TEX2PDF_SCOPES = os.environ.get("TEX2PDF_SCOPES", _DEFAULT_TEX2PDF_SCOPES)
     # initialize TEX2PDF_KEYS_TO_URLS from env vars
-    #   TEX2PDF_KEYS_TO_URLS_<key> = <url>
+    #   _TEX2PDF_KEYS_TO_URLS_<key> = <url>
+    _TEX2PDF_KEYS_TO_URLS: dict[str, str] = {}
     for key, value in os.environ.items():
         if key.startswith("TEX2PDF_KEYS_TO_URLS_"):
             url_key = key[len("TEX2PDF_KEYS_TO_URLS_") :]
-            TEX2PDF_KEYS_TO_URLS[url_key] = value
+            _TEX2PDF_KEYS_TO_URLS[url_key] = value
+    if _TEX2PDF_KEYS_TO_URLS:
+        TEX2PDF_KEYS_TO_URLS = _TEX2PDF_KEYS_TO_URLS
+        TEX2PDF_SCOPES = os.environ.get("TEX2PDF_SCOPES", "")
+    elif PROJECT_NR != 0:
+        # defaults
+        TEX2PDF_KEYS_TO_URLS = {
+            "autotex-te2": f"https://tex2pdf-autotex-te2-{PROJECT_NR}.us-central1.run.app/autotex/",
+            "autotex-te3": f"https://tex2pdf-autotex-te3-{PROJECT_NR}.us-central1.run.app/autotex/",
+            "autotex-tl2009": f"https://tex2pdf-autotex-tl2009-{PROJECT_NR}.us-central1.run.app/autotex/",
+            "autotex-tl2011": f"https://tex2pdf-autotex-tl2011-{PROJECT_NR}.us-central1.run.app/autotex/",
+            "autotex-tl2016": f"https://tex2pdf-autotex-tl2016-{PROJECT_NR}.us-central1.run.app/autotex/",
+            "autotex-tl2020": f"https://tex2pdf-autotex-tl2020-{PROJECT_NR}.us-central1.run.app/autotex/",
+            "autotex-tl2023": f"https://tex2pdf-autotex-tl2020-{PROJECT_NR}.us-central1.run.app/autotex/",
+            "tl2023": f"https://tex-to-pdf-2023-{PROJECT_NR}.us-central1.run.app/convert/",
+            "tl2025": f"https://tex-to-pdf-2025-{PROJECT_NR}.us-central1.run.app/convert/",
+        }
+        # TODO how to deal with parallel v1 and v1.5 submissions where we have autotex-tl2023 and tl2023?
+        # Idea to be implemented:
+        # - allow for autotex-XXXX and XXXX in the left part of the scope
+        # - check for presence of autotex-XXXX prefix to distinguish between v1 and v1.5 submissions
+        # - we also need a "auto" variant that uses the ZZRM set version!
+        DEFAULT_SCOPES = (
+            "autotex-te2:1162425600:"
+            "autotex-te3:1262217600:"
+            "autotex-tl2009:1323129600:"
+            "autotex-tl2011:1486670400:"
+            "autotex-tl2016:1601553600:"
+            "autotex-tl2020:1684778400:"
+            "autotex-tl2023,tl2023:1767225600:"
+            "tl2025"
+        )
+        TEX2PDF_SCOPES = os.environ.get("TEX2PDF_SCOPES", DEFAULT_SCOPES)
+    else:
+        # neither env vars nor project number set, just default to no proxy
+        TEX2PDF_PROXY_RELEASE = "0"
+        TEX2PDF_KEYS_TO_URLS = {}
+        TEX2PDF_SCOPES = ""
 
 
 class CustomJsonFormatter(JsonFormatter):


### PR DESCRIPTION
Since we have parallel submissions running, we must be able to
determine the compilation system not only based on the timestamp,
but also whether a ZZRM is present (or is auto-generated) or not.

This PR allows multiple entries in the scope definitions, one for `autotex-*`
and one for plain (no autotex-).

If a ZZRM is present or generated, the non-autotex one is choosen, otherwise
the autotex one is choosen.