### PR TITLE
Refactor remote call routines

### DIFF
--- a/.github/workflows/test_modules.yaml
+++ b/.github/workflows/test_modules.yaml
@@ -47,6 +47,8 @@ jobs:
         export PYTHONPATH=$PWD
         poetry run pytest tests
     - uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.12.x"
     - run: ruff check
     - run: ruff format --check --diff
 

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -678,7 +678,7 @@ class RemoteConverterDriver(ConverterDriver):
                     meta["pdf_file"] = pdf_files[0]
                 break
         self.outcome = meta
-        logger.debug("Dumping meta %s", meta)
+        # logger.debug("Dumping meta %s", meta)
         logger.debug("Checking for ZZRM")
 
         # we need to get ZZRM

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -664,7 +664,7 @@ class RemoteConverterDriver(ConverterDriver):
                     meta.update(json.load(json_file))
                 break
         self.outcome = meta
-        # logger.debug("Dumping meta %s", meta)
+        logger.debug("Dumping meta %s", meta)
         logger.debug("Checking for ZZRM")
 
         # we need to get ZZRM
@@ -678,6 +678,7 @@ class RemoteConverterDriver(ConverterDriver):
 
         logger.debug("Directory listing of %s is: %s", self.out_dir, os.listdir(self.out_dir))
 
+        logger.debug("Outcome pdf file: %s", self.outcome.get("pdf_file"))
         return self.outcome.get("pdf_file")
 
 

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -642,8 +642,10 @@ class RemoteConverterDriver(ConverterDriver):
             self.source,
             outcome_file,
             int(self.max_time_budget),
-            self.auto_detect,
-            self.hide_anc_dir,
+            watermark_text=self.water.text,
+            watermark_link=self.water.link,
+            auto_detect=self.auto_detect,
+            hide_anc_dir=self.hide_anc_dir,
         )
 
         if not success:

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -637,10 +637,11 @@ class RemoteConverterDriver(ConverterDriver):
         logger.debug("Submitting %s to %s with output to %s", local_tarball, self.service, outcome_file)
         success = service_process_tarball(
             self.service,
-            local_tarball,
+            self.work_dir,
+            tag,
+            self.source,
             outcome_file,
             int(self.max_time_budget),
-            self.post_timeout,
             self.auto_detect,
             self.hide_anc_dir,
         )

--- a/tex2pdf-service/tex2pdf/remote_call.py
+++ b/tex2pdf-service/tex2pdf/remote_call.py
@@ -5,8 +5,12 @@ import logging
 import os
 import tarfile
 import time
+import traceback
+import typing
 
 import requests
+
+from .service_logger import get_logger
 
 
 def get_outcome_meta(outcome_file: str) -> dict:
@@ -21,14 +25,141 @@ def get_outcome_meta(outcome_file: str) -> dict:
     return meta
 
 
+def convert_pdf_remote(
+    compile_service: str,
+    arxivid: str | None,
+    tempdir: str,
+    tag: str,
+    source: str,
+    use_addon_tree: bool,
+    timeout: float | None,
+    max_tex_files: int | None,
+    max_appending_files: int | None,
+    watermark_text: str | None = None,
+    watermark_link: str | None = None,
+    auto_detect: bool = False,
+    hide_anc_dir: bool = False,
+    log_extra: dict[str, typing.Any] = {},
+) -> tuple[int, str]:
+    logger = get_logger()
+    tarball = os.path.join(tempdir, source)
+    # make sure we have a trailing slash
+    compile_service = compile_service.rstrip("/") + "/"
+    with open(tarball, "rb") as data_fd:
+        uploading = {"incoming": (source, data_fd, "application/gzip")}
+        retries = 2
+        for attempt in range(1 + retries):
+            try:
+                if compile_service.endswith("convert/"):
+                    args_dict = {
+                        "timeout": timeout,
+                        "use_addon_tree": use_addon_tree,
+                        "max_tex_files": max_tex_files,
+                        "max_appending_files": max_appending_files,
+                        "watermark_text": watermark_text,
+                        "watermark_link": watermark_link,
+                        "auto_detect": auto_detect,
+                        "hide_anc_dir": hide_anc_dir,
+                    }
+                else:
+                    args_dict = {
+                        "timeout": timeout,
+                        "arxivid": arxivid,
+                    }
+                logger.debug("POST URL: %s, args = %s", compile_service, args_dict, extra=log_extra)
+                logger.debug("uploading = %s", uploading, extra=log_extra)
+                try:
+                    res = requests.post(
+                        compile_service,
+                        files=uploading,
+                        timeout=timeout,
+                        allow_redirects=False,
+                        params=args_dict,
+                    )
+                except ConnectionError as e:
+                    logger.warning(
+                        "Failed to submit tarball %s to %s, connection error: %s",
+                        tarball,
+                        compile_service,
+                        e,
+                        extra=log_extra,
+                    )
+                    return 422, "Failed to submit tarball: connection error"
+                status_code = res.status_code
+                logger.debug("Received status code %d from POST to %s", status_code, res.url, extra=log_extra)
+                if status_code == 504:
+                    # This is the only place we retry, and at most 3 times in total.
+                    logger.warning("Got 504 for %s", compile_service, extra=log_extra)
+                    time.sleep(1)
+                    # we need to rewind the data_fd otherwise the next request will send
+                    # an empty file.
+                    data_fd.seek(0)
+                    continue
+
+                # Deal with failures
+                if status_code == 400 or status_code == 422 or status_code == 500:
+                    logger.warning(
+                        "Failed to submit tarball %s to %s, status code: %d, %s",
+                        tarball,
+                        compile_service,
+                        status_code,
+                        res.text,
+                        extra=log_extra,
+                    )
+                    return status_code, f"Failed to submit tarball: {res.text}"
+
+                elif status_code == 200:
+                    # it would be better to forward the streaming response directly to the caller
+                    # one approach is explained here: https://stackoverflow.com/a/73299661
+                    if res.content:
+                        out_filename = f"{tag}-outcome.tar.gz"
+                        out_path = os.path.join(tempdir, out_filename)
+                        with open(out_path, "wb") as out_file:
+                            out_file.write(res.content)
+                        return status_code, out_path
+                    else:
+                        logger.warning(
+                            "Failed to submit tarball %s to %s, status code: %d, %s",
+                            tarball,
+                            compile_service,
+                            status_code,
+                            res.text,
+                            extra=log_extra,
+                        )
+                        return status_code, "Failed to submit tarball: {res.text}"
+                else:
+                    logger.warning(
+                        "Unexpected status code %d from %s: %s",
+                        status_code,
+                        compile_service,
+                        res.text,
+                        extra=log_extra,
+                    )
+                    return status_code, f"Unexpected status code: {status_code}"
+
+            except TimeoutError:
+                logger.warning("%s: Connection to %s timed out", tarball, compile_service, extra=log_extra)
+                return 500, "Timeout contacting remote service"
+            except Exception as exc:
+                logger.warning("Exception submitting tarball: %s", exc, exc_info=True, extra=log_extra)
+                logger.warning("%s: %s", tarball, str(exc), extra=log_extra)
+                return 500, "General exception: " + traceback.format_exc()
+        logger.error(
+            "Failed to submit tarball %s to %s after %d attempts", tarball, compile_service, retries, extra=log_extra
+        )
+        return 500, "Failed to submit tarball after multiple attempts"
+
+
 def service_process_tarball(
     service: str,
+    tempdir: str,
     tarball: str,
     outcome_file: str,
     tex2pdf_timeout: int,
     post_timeout: int,
     auto_detect: bool = False,
     hide_anc_dir: bool = False,
+    log_extra: dict[str, typing.Any] = {},
 ) -> bool:
     """Submit tarball to compilation service and receive result."""
     if os.path.exists(outcome_file):
@@ -38,39 +169,21 @@ def service_process_tarball(
     meta = {}
     status_code = None
 
-    with open(tarball, "rb") as data_fd:
-        uploading = {"incoming": (os.path.basename(tarball), data_fd, "application/gzip")}
-        retries = 2
-        for attempt in range(1 + retries):
-            try:
-                post_url = service + f"?timeout={tex2pdf_timeout}&auto_detect={auto_detect}&hide_anc_dir={hide_anc_dir}"
-                logging.debug("POST URL: %s", post_url)
-                logging.debug("uploading = %s", uploading)
-                res = requests.post(
-                    post_url,
-                    files=uploading,
-                    timeout=post_timeout,
-                    allow_redirects=False,
-                )
-                status_code = res.status_code
-                if status_code == 504:
-                    # This is the only place we retry, and at most 3 times in total.
-                    logging.warning("Got 504 for %s", service)
-                    time.sleep(1)
-                    continue
+    status_code, msg = convert_pdf_remote(
+        service,
+        None,
+        tempdir,
+        os.path.basename(tarball),
+        tarball,
+        False,
+        post_timeout,
+        auto_detect=auto_detect,
+        hide_anc_dir=hide_anc_dir,
+        log_extra=log_extra,
+    )
 
-                if status_code == 200:
-                    if res.content:
-                        with open(outcome_file, "wb") as out:
-                            out.write(res.content)
-                        meta = get_outcome_meta(outcome_file)
-            except TimeoutError:
-                logging.warning("%s: Connection timed out", tarball)
-
-            except Exception as exc:
-                logging.warning("Exception submitting tarball: %s", exc)
-                logging.warning("%s: %s", tarball, str(exc))
-            break
+    if status_code == 200:
+        meta = get_outcome_meta(msg)
 
     success = meta.get("status") == "success"
     logging.log(

--- a/tex2pdf-service/tex2pdf/remote_call.py
+++ b/tex2pdf-service/tex2pdf/remote_call.py
@@ -54,7 +54,7 @@ def convert_pdf_remote(
     :param max_tex_files: maximum number of .tex files allowed to be compiled
     :param max_appending_files: maximum number of files allowed to be appended
     :param watermark_text: optional watermark text to add to the PDF
-    :param watermark_link: optional link for the watermark
+    :param watermark_link: optional watermark link to add to the PDF
     :param auto_detect: whether to auto-detect the main .tex file using preflight
     :param hide_anc_dir: whether to hide the ancillary directory during compilation
     :param log_extra: extra context for logging
@@ -69,14 +69,13 @@ def convert_pdf_remote(
         retries = 2
         for attempt in range(1 + retries):
             try:
+                args_dict: dict[str, typing.Any]
                 if compile_service.endswith("convert/"):
                     args_dict = {
                         "timeout": timeout,
                         "use_addon_tree": use_addon_tree,
                         "max_tex_files": max_tex_files,
                         "max_appending_files": max_appending_files,
-                        "watermark_text": watermark_text,
-                        "watermark_link": watermark_link,
                         "auto_detect": auto_detect,
                         "hide_anc_dir": hide_anc_dir,
                     }
@@ -85,6 +84,10 @@ def convert_pdf_remote(
                         "timeout": timeout,
                         "arxivid": arxivid,
                     }
+                if watermark_text:
+                    args_dict["watermark_text"] = watermark_text
+                    if watermark_link:
+                        args_dict["watermark_link"] = watermark_link
                 logger.debug("POST URL: %s, args = %s", compile_service, args_dict, extra=log_extra)
                 logger.debug("uploading = %s", uploading, extra=log_extra)
                 try:
@@ -180,6 +183,8 @@ def service_process_tarball(
     tarball: str,
     outcome_file: str,
     post_timeout: int,
+    watermark_text: str | None = None,
+    watermark_link: str | None = None,
     auto_detect: bool = False,
     hide_anc_dir: bool = False,
     log_extra: dict[str, typing.Any] = {},
@@ -191,6 +196,8 @@ def service_process_tarball(
     :param tag: tag to use in naming the outcome tarball
     :param tarball: path to the source tarball to submit
     :param outcome_file: path to save the outcome tarball
+    :param watermark_text: optional watermark text to add to the PDF
+    :param watermark_link: optional watermark link to add to the PDF
     :param post_timeout: timeout for the request in seconds
     :param auto_detect: whether to auto-detect the main .tex file using preflight
     :param hide_anc_dir: whether to hide the ancillary directory during compilation
@@ -213,6 +220,8 @@ def service_process_tarball(
         tarball,
         False,
         post_timeout,
+        watermark_text=watermark_text,
+        watermark_link=watermark_link,
         max_tex_files=None,
         max_appending_files=None,
         auto_detect=auto_detect,

--- a/tex2pdf-service/tex2pdf/tex2pdf_api.py
+++ b/tex2pdf-service/tex2pdf/tex2pdf_api.py
@@ -4,13 +4,11 @@ import os
 import re
 import subprocess
 import tempfile
-import time
 import traceback
 import typing
 from enum import Enum
 from pathlib import Path
 
-import requests
 from arxiv.identifier import Identifier as arXivID
 from arxiv.identifier import IdentifierException
 from fastapi import FastAPI, Query, UploadFile
@@ -39,6 +37,7 @@ from . import (
 from .converter_driver import AutoTeXConverterDriver, ConversionOutcomeMaker, ConverterDriver
 from .fastapi_util import closer
 from .pdf_watermark import Watermark, WatermarkError, WatermarkFileTypeError, add_watermark_text_to_pdf
+from .remote_call import convert_pdf_remote
 from .service_logger import get_logger
 from .tarball import (
     RemovedSubmission,
@@ -399,12 +398,11 @@ async def convert_pdf(
                 log_extra=log_extra,
             )
         else:
-            logger.info("Using RemoteConverterDriver")
-            return _convert_pdf_remote(
+            logger.info("Using convert_pdf_remote")
+            status_code, msg = convert_pdf_remote(
                 compile_service=compile_service,
                 arxivid=arxivid,
                 tempdir=tempdir,
-                in_dir=in_dir,
                 tag=tag,
                 source=filename,
                 use_addon_tree=use_addon_tree,
@@ -417,158 +415,15 @@ async def convert_pdf(
                 hide_anc_dir=hide_anc_dir,
                 log_extra=log_extra,
             )
-
-
-def _convert_pdf_remote(
-    compile_service: str,
-    arxivid: str | None,
-    tempdir: str,
-    in_dir: str,
-    tag: str,
-    source: str,
-    use_addon_tree: bool,
-    timeout: float | None,
-    max_tex_files: int | None,
-    max_appending_files: int | None,
-    watermark_text: str | None = None,
-    watermark_link: str | None = None,
-    auto_detect: bool = False,
-    hide_anc_dir: bool = False,
-    log_extra: dict[str, typing.Any] = {},
-) -> Response:
-    logger = get_logger()
-    tarball = os.path.join(tempdir, source)
-    # make sure we have a trailing slash
-    compile_service = compile_service.rstrip("/") + "/"
-    with open(tarball, "rb") as data_fd:
-        uploading = {"incoming": (source, data_fd, "application/gzip")}
-        retries = 2
-        for attempt in range(1 + retries):
-            try:
-                if compile_service.endswith("convert/"):
-                    args_dict = {
-                        "timeout": timeout,
-                        "use_addon_tree": use_addon_tree,
-                        "max_tex_files": max_tex_files,
-                        "max_appending_files": max_appending_files,
-                        "watermark_text": watermark_text,
-                        "watermark_link": watermark_link,
-                        "auto_detect": auto_detect,
-                        "hide_anc_dir": hide_anc_dir,
-                    }
-                else:
-                    args_dict = {
-                        "timeout": timeout,
-                        "arxivid": arxivid,
-                    }
-                logger.debug("POST URL: %s, args = %s", compile_service, args_dict, extra=log_extra)
-                logger.debug("uploading = %s", uploading, extra=log_extra)
-                try:
-                    res = requests.post(
-                        compile_service,
-                        files=uploading,
-                        timeout=timeout,
-                        allow_redirects=False,
-                        params=args_dict,
-                    )
-                except ConnectionError as e:
-                    logger.warning(
-                        "Failed to submit tarball %s to %s, connection error: %s",
-                        tarball,
-                        compile_service,
-                        e,
-                        extra=log_extra,
-                    )
-                    return JSONResponse(
-                        status_code=422,
-                        content={"message": "Failed to submit tarball: connection error"},
-                    )
-                status_code = res.status_code
-                logger.debug("Received status code %d from POST to %s", status_code, res.url, extra=log_extra)
-                if status_code == 504:
-                    # This is the only place we retry, and at most 3 times in total.
-                    logger.warning("Got 504 for %s", compile_service, extra=log_extra)
-                    time.sleep(1)
-                    # we need to rewind the data_fd otherwise the next request will send
-                    # an empty file.
-                    data_fd.seek(0)
-                    continue
-
-                # Deal with failures
-                if status_code == 400 or status_code == 422 or status_code == 500:
-                    logger.warning(
-                        "Failed to submit tarball %s to %s, status code: %d, %s",
-                        tarball,
-                        compile_service,
-                        status_code,
-                        res.text,
-                        extra=log_extra,
-                    )
-                    return JSONResponse(
-                        status_code=status_code,
-                        content={"message": f"Failed to submit tarball: {res.text}"},
-                    )
-
-                elif status_code == 200:
-                    # it would be better to forward the streaming response directly to the caller
-                    # one approach is explained here: https://stackoverflow.com/a/73299661
-                    if res.content:
-                        out_filename = f"{tag}-outcome.tar.gz"
-                        out_path = os.path.join(tempdir, out_filename)
-                        with open(out_path, "wb") as out_file:
-                            out_file.write(res.content)
-                        headers = {
-                            "Content-Type": "application/gzip",
-                            "Content-Disposition": f"attachment; filename={out_filename}",
-                        }
-                        content = open(out_path, "rb")
-                        return GzipResponse(content, headers=headers, background=closer(content, source, log_extra))
-                    else:
-                        logger.warning(
-                            "Failed to submit tarball %s to %s, status code: %d, %s",
-                            tarball,
-                            compile_service,
-                            status_code,
-                            res.text,
-                            extra=log_extra,
-                        )
-                        return JSONResponse(
-                            status_code=status_code,
-                            content={"message": f"Failed to submit tarball: {res.text}"},
-                        )
-                else:
-                    logger.warning(
-                        "Unexpected status code %d from %s: %s",
-                        status_code,
-                        compile_service,
-                        res.text,
-                        extra=log_extra,
-                    )
-                    return JSONResponse(
-                        status_code=status_code,
-                        content={"message": f"Unexpected status code: {status_code}"},
-                    )
-
-            except TimeoutError:
-                logger.warning("%s: Connection to %s timed out", tarball, compile_service, extra=log_extra)
-                return JSONResponse(
-                    status_code=STATCODE.HTTP_500_INTERNAL_SERVER_ERROR,
-                    content={"message": "Timeout contacting remote service"},
-                )
-            except Exception as exc:
-                logger.warning("Exception submitting tarball: %s", exc, exc_info=True, extra=log_extra)
-                logger.warning("%s: %s", tarball, str(exc), extra=log_extra)
-                return JSONResponse(
-                    status_code=STATCODE.HTTP_500_INTERNAL_SERVER_ERROR,
-                    content={"message": "General exception: " + traceback.format_exc()},
-                )
-        logger.error(
-            "Failed to submit tarball %s to %s after %d attempts", tarball, compile_service, retries, extra=log_extra
-        )
-        return JSONResponse(
-            status_code=STATCODE.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"message": "Failed to submit tarball after multiple attempts"},
-        )
+            if status_code == 200:
+                headers = {
+                    "Content-Type": "application/gzip",
+                    "Content-Disposition": f"attachment; filename={os.path.basename(msg)}",
+                }
+                content = open(msg, "rb")
+                return GzipResponse(content, headers=headers, background=closer(content, msg, log_extra))
+            else:
+                return JSONResponse(status_code=status_code, content={"message": msg})
 
 
 def _convert_pdf_current(

--- a/tex2pdf-service/tex2pdf/tex2pdf_api.py
+++ b/tex2pdf-service/tex2pdf/tex2pdf_api.py
@@ -402,9 +402,9 @@ async def convert_pdf(
             status_code, msg = convert_pdf_remote(
                 compile_service=compile_service,
                 arxivid=arxivid,
-                tempdir=tempdir,
+                output_dir=tempdir,
                 tag=tag,
-                source=filename,
+                source_path=local_tarball,
                 use_addon_tree=use_addon_tree,
                 timeout=timeout_secs,
                 max_tex_files=max_tex_files,


### PR DESCRIPTION
We have two different methods, one in the RemoteConverterDriver and one
in the tex2pdf api. Factor out the better code and use it in both situations.
