### PR TITLE
[preflight] warn when bbl version == 3.2 that TL2023 is needed

### DIFF
--- a/tex2pdf-tools/tests/preflight/fixture/biblatex-bibliography/main.bbl
+++ b/tex2pdf-tools/tests/preflight/fixture/biblatex-bibliography/main.bbl
@@ -1,5 +1,5 @@
 % $ biblatex auxiliary file $
-% $ biblatex bbl format version 3.2 $
+% $ biblatex bbl format version 3.3 $
 % Do not modify the above lines!
 %
 % This is an auxiliary file used by the 'biblatex' package.
@@ -18,8 +18,8 @@
 
 
 \refsection{0}
-  \datalist[entry]{nty/global//global/global}
-    \entry{abc}{misc}{}
+  \datalist[entry]{nty/global//global/global/global}
+    \entry{abc}{misc}{}{}
       \name{author}{1}{}{%
         {{hash=aaec8f7cde1b31eaf9a852e971919860}{%
            family={Someone},
@@ -27,10 +27,12 @@
       }
       \strng{namehash}{aaec8f7cde1b31eaf9a852e971919860}
       \strng{fullhash}{aaec8f7cde1b31eaf9a852e971919860}
+      \strng{fullhashraw}{aaec8f7cde1b31eaf9a852e971919860}
       \strng{bibnamehash}{aaec8f7cde1b31eaf9a852e971919860}
       \strng{authorbibnamehash}{aaec8f7cde1b31eaf9a852e971919860}
       \strng{authornamehash}{aaec8f7cde1b31eaf9a852e971919860}
       \strng{authorfullhash}{aaec8f7cde1b31eaf9a852e971919860}
+      \strng{authorfullhashraw}{aaec8f7cde1b31eaf9a852e971919860}
       \field{sortinit}{S}
       \field{sortinithash}{b164b07b29984b41daf1e85279fbc5ab}
       \field{labelnamesource}{author}

--- a/tex2pdf-tools/tests/preflight/test_preflight.py
+++ b/tex2pdf-tools/tests/preflight/test_preflight.py
@@ -349,7 +349,8 @@ class TestPreflight(unittest.TestCase):
         self.assertTrue(tf.process.bibliography.pre_generated)
         self.assertEqual(len(pf.tex_files), 1)
         tf = pf.tex_files[0]
-        self.assertEqual(len(tf.issues), 0)
+        self.assertEqual(len(tf.issues), 1)
+        self.assertEqual(tf.issues[0].key, IssueType.bbl_version_needs_previous_version)
 
     def test_biber_good_version_33(self):
         """Test bbl version not matching arXiv TeX version."""


### PR DESCRIPTION
The setup is more general and will be able to adjust to further version squeezes between supported TL versions easily.

In case the previous TL version (the one we still support) allows for this bbl file version, we add an issue with issue type
	bbl_version_needs_previous_version
The frontend can show an appropriate warning and possible auto-select the TL version.

Update unittests for current state.