### PR TITLE
[SUBMISSION-107] [tex2pdf-tools] drop all zzrm formats but .json and v1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,89 @@
+# Build context for tex2pdf-service/Appliance.Dockerfile is the repo root.
+# Keep that context lean: ignore everything that .gitignore covers plus the
+# usual local-only test artifacts and editor noise.
+
+# Git / version control
+.git
+.gitignore
+.gitattributes
+
+# Byte-compiled / packaging / venvs
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Test / coverage / type-checker caches
+.pytest_cache/
+.cache
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.nox/
+.hypothesis/
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+cover/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+.pytype/
+.ruff_cache/
+
+# Local test outputs (uncommitted)
+tex2pdf-service/tests/output/
+tex2pdf-tools/*.json
+
+# Logs and reports
+*.log
+tex2pdf-service/reports/
+
+# Editor / IDE
+.idea/
+.vscode/
+*~
+\#*
+.python-version
+
+# Other monorepo subprojects we never need in the build context
+pdf_profile/
+
+# Top-level scratch / notes (untracked)
+encrypted-sub/
+sword/
+
+# CI / Docker meta — not needed inside the build
+.github/
+.dockerignore

--- a/.github/workflows/test_service.yaml
+++ b/.github/workflows/test_service.yaml
@@ -68,6 +68,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest poetry
         poetry install
+        # Overlay the in-tree tex2pdf-tools so CI tests against the working
+        # copy, not the GitHub-pinned commit recorded in poetry.lock.
+        poetry run pip install --no-deps -e ../tex2pdf-tools
     - name: pytest for tex2pdf
       run: |
         cd tex2pdf-service

--- a/tex2pdf-service/Appliance.Dockerfile
+++ b/tex2pdf-service/Appliance.Dockerfile
@@ -36,15 +36,22 @@ RUN useradd -m -d $WORKER_HOME -s /bin/bash -g users -u 1000 worker
 RUN chown worker:users $WORKER_HOME
 USER worker
 WORKDIR $WORKER_HOME
-COPY poetry.lock pyproject.toml ./
+COPY tex2pdf-service/poetry.lock tex2pdf-service/pyproject.toml ./
+# Bring the local tex2pdf-tools tree into the build context so we can overlay
+# it on top of the GitHub-pinned copy that poetry installs.
+COPY tex2pdf-tools/ /tmp/tex2pdf-tools/
 # poetry is BROKEN wrt to installing multiple packages from same git repo
 # see https://github.com/python-poetry/poetry/issues/6958
 # RUN poetry config installer.parallel false
 # install runtime deps - uses $POETRY_VIRTUALENVS_IN_PROJECT internally
 RUN poetry install --no-root --without=dev
+# Replace the pinned arxiv-tex2pdf-tools wheel with one built from the local
+# source so the image carries the working-tree version, not the GitHub commit
+# pinned in poetry.lock.
+RUN poetry run pip install --no-deps /tmp/tex2pdf-tools
 
 # copy this afterwards to avoid re-installing poetry deps on each docker build
-COPY tex2pdf/ ./tex2pdf/
+COPY tex2pdf-service/tex2pdf/ ./tex2pdf/
 # second poetry run should only install the current project
 RUN poetry install --without=dev
 
@@ -67,11 +74,11 @@ ENV PYTHONUNBUFFERED=1 \
 
 # install the arXiv specific changes:
 # - special settings in texmf.cnf
-COPY texlive/common/texmf.cnf /usr/local/texlive/${TEXLIVE_BASE_RELEASE}/
+COPY tex2pdf-service/texlive/common/texmf.cnf /usr/local/texlive/${TEXLIVE_BASE_RELEASE}/
 
 COPY --from=arxiv-texlive-builder $WORKER_HOME $WORKER_HOME
 
-COPY bin/bwrap-tex.sh /usr/local/bin/bwrap-tex.sh
+COPY tex2pdf-service/bin/bwrap-tex.sh /usr/local/bin/bwrap-tex.sh
 
 # -M don't create home since we copied it above
 RUN useradd -M -d $WORKER_HOME -s /bin/bash -g users -u 1000 worker
@@ -81,8 +88,8 @@ WORKDIR $WORKER_HOME
 
 # application specific changes
 ENV PYTHONPATH=$WORKER_HOME
-COPY app-logging.conf .
-COPY app-logging.json .
-COPY hypercorn-config.toml .
-COPY app.sh ./app.sh
+COPY tex2pdf-service/app-logging.conf .
+COPY tex2pdf-service/app-logging.json .
+COPY tex2pdf-service/hypercorn-config.toml .
+COPY tex2pdf-service/app.sh ./app.sh
 CMD ["/bin/bash", "app.sh"]

--- a/tex2pdf-service/Makefile
+++ b/tex2pdf-service/Makefile
@@ -67,7 +67,7 @@ app2023.docker:
 	@echo "PLATFORM: ${PLATFORM}"
 	@echo "dockerport: ${app_2023_port}"
 	@echo "tag: ${app_tag}-${base_2023_tag_version}:latest"
-	docker buildx build -f tex2pdf-service/Appliance.Dockerfile \
+	docker buildx build -f ./Appliance.Dockerfile \
 		--progress=plain \
 		--build-arg TEXLIVE_BASE_RELEASE=${TEXLIVE_2023_BASE_RELEASE} \
 		--build-arg TEXLIVE_BASE_IMAGE_DATE=${TEXLIVE_2023_BASE_IMAGE_DATE} \
@@ -82,7 +82,7 @@ app2024.docker:
 	@echo "PLATFORM: ${PLATFORM}"
 	@echo "dockerport: ${app_2024_port}"
 	@echo "tag: ${app_tag}-${base_2024_tag_version}:latest"
-	docker buildx build -f tex2pdf-service/Appliance.Dockerfile \
+	docker buildx build -f ./Appliance.Dockerfile \
 		--progress=plain \
 		--build-arg TEXLIVE_BASE_RELEASE=${TEXLIVE_2024_BASE_RELEASE} \
 		--build-arg TEXLIVE_BASE_IMAGE_DATE=${TEXLIVE_2024_BASE_IMAGE_DATE} \
@@ -97,7 +97,7 @@ app2025.docker:
 	@echo "PLATFORM: ${PLATFORM}"
 	@echo "dockerport: ${app_2025_port}"
 	@echo "tag: ${app_tag}-${base_2025_tag_version}:latest"
-	docker buildx build -f tex2pdf-service/Appliance.Dockerfile \
+	docker buildx build -f ./Appliance.Dockerfile \
 		--progress=plain \
 		--build-arg TEXLIVE_BASE_RELEASE=${TEXLIVE_2025_BASE_RELEASE} \
 		--build-arg TEXLIVE_BASE_IMAGE_DATE=${TEXLIVE_2025_BASE_IMAGE_DATE} \

--- a/tex2pdf-service/Makefile
+++ b/tex2pdf-service/Makefile
@@ -28,7 +28,15 @@ EXTRA_DOCKER_ARGS ?=
 
 APP_DOCKER_RUN := docker run --cpus ${TEX2PDF_CPUS} --rm -e PORT=${dockerport} -e WORKERS=${TEX2PDF_WORKERS} --security-opt="no-new-privileges=true" ${EXTRA_DOCKER_ARGS}
 
-.PHONY: HELLO app.docker app.run app.stop
+.PHONY: HELLO app.docker app.run app.stop install.dev
+
+#-#
+#-# Command: install.dev
+#-#   poetry install + editable overlay of ../tex2pdf-tools so local edits to
+#-#   the tools tree are picked up immediately by tests
+install.dev:
+	poetry install
+	poetry run pip install --no-deps -e ../tex2pdf-tools
 
 default: HELLO
 
@@ -59,12 +67,12 @@ app2023.docker:
 	@echo "PLATFORM: ${PLATFORM}"
 	@echo "dockerport: ${app_2023_port}"
 	@echo "tag: ${app_tag}-${base_2023_tag_version}:latest"
-	docker buildx build -f ./Appliance.Dockerfile \
+	docker buildx build -f tex2pdf-service/Appliance.Dockerfile \
 		--progress=plain \
 		--build-arg TEXLIVE_BASE_RELEASE=${TEXLIVE_2023_BASE_RELEASE} \
 		--build-arg TEXLIVE_BASE_IMAGE_DATE=${TEXLIVE_2023_BASE_IMAGE_DATE} \
 		--build-arg GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD) \
-		--platform=linux/amd64 -t ${app_tag}-${base_2023_tag_version}:latest .
+		--platform=linux/amd64 -t ${app_tag}-${base_2023_tag_version}:latest ..
 
 app2024.docker:
 	@if [ -n "$$INSIDE_EMACS" ]; then \
@@ -74,12 +82,12 @@ app2024.docker:
 	@echo "PLATFORM: ${PLATFORM}"
 	@echo "dockerport: ${app_2024_port}"
 	@echo "tag: ${app_tag}-${base_2024_tag_version}:latest"
-	docker buildx build -f ./Appliance.Dockerfile \
+	docker buildx build -f tex2pdf-service/Appliance.Dockerfile \
 		--progress=plain \
 		--build-arg TEXLIVE_BASE_RELEASE=${TEXLIVE_2024_BASE_RELEASE} \
 		--build-arg TEXLIVE_BASE_IMAGE_DATE=${TEXLIVE_2024_BASE_IMAGE_DATE} \
 		--build-arg GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD) \
-		--platform=linux/amd64 -t ${app_tag}-${base_2024_tag_version}:latest .
+		--platform=linux/amd64 -t ${app_tag}-${base_2024_tag_version}:latest ..
 
 app2025.docker:
 	@if [ -n "$$INSIDE_EMACS" ]; then \
@@ -89,12 +97,12 @@ app2025.docker:
 	@echo "PLATFORM: ${PLATFORM}"
 	@echo "dockerport: ${app_2025_port}"
 	@echo "tag: ${app_tag}-${base_2025_tag_version}:latest"
-	docker buildx build -f ./Appliance.Dockerfile \
+	docker buildx build -f tex2pdf-service/Appliance.Dockerfile \
 		--progress=plain \
 		--build-arg TEXLIVE_BASE_RELEASE=${TEXLIVE_2025_BASE_RELEASE} \
 		--build-arg TEXLIVE_BASE_IMAGE_DATE=${TEXLIVE_2025_BASE_IMAGE_DATE} \
 		--build-arg GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD) \
-		--platform=linux/amd64 -t ${app_tag}-${base_2025_tag_version}:latest .
+		--platform=linux/amd64 -t ${app_tag}-${base_2025_tag_version}:latest ..
 
 
 # Our test setup is:

--- a/tex2pdf-service/tex2pdf/converter_driver.py
+++ b/tex2pdf-service/tex2pdf/converter_driver.py
@@ -1,6 +1,5 @@
 """This module is the core of the PDF generation. It takes a tarball, unpack it, and generate PDF."""
 
-import io
 import json
 import os
 import random
@@ -578,10 +577,7 @@ class ConversionOutcomeMaker:
 
         zzrm = converter_driver.zzrm
         assert zzrm is not None
-        zzrm_generated = io.StringIO()
-        zzrm.to_yaml(zzrm_generated)
-        zzrm_generated.seek(0)
-        zzrm_text = zzrm_generated.read()
+        zzrm_text = zzrm.to_json()
         outcome_meta = {
             "version": 1,  # outcome format version
             "version_info": f"{self.gen_id}:{GIT_COMMIT_HASH}",

--- a/tex2pdf-tools/tests/preflight/test_preflight.py
+++ b/tex2pdf-tools/tests/preflight/test_preflight.py
@@ -1159,3 +1159,20 @@ def test_graphics_no_driver_option():
         if i.key in (IssueType.graphics_driver_option, IssueType.graphics_driver_unsupported)
     ]
     assert len(driver_issues) == 0
+
+
+def test_preflight_unsupported_zzrm_format(tmp_path):
+    """An uploaded 00README.yaml should produce an unsupported_zzrm_format issue."""
+    (tmp_path / "main.tex").write_text(
+        r"\documentclass{article}\begin{document}hello\end{document}"
+    )
+    (tmp_path / "00README.yaml").write_text("process:\n  compiler: pdflatex\n")
+    pf: PreflightResponse = generate_preflight_response(str(tmp_path))
+    assert pf.status.key.value == "success"
+    assert len(pf.detected_toplevel_files) == 1
+    issues = pf.detected_toplevel_files[0].issues
+    assert any(
+        i.key == IssueType.unsupported_zzrm_format and i.filename == "00README.yaml"
+        for i in issues
+    )
+

--- a/tex2pdf-tools/tests/zerozeroreadme/test_zzrm.py
+++ b/tex2pdf-tools/tests/zerozeroreadme/test_zzrm.py
@@ -1,10 +1,14 @@
-import io
 import os
 import unittest
 
 import pytest
 
-from tex2pdf_tools.zerozeroreadme import ZeroZeroReadMe, ZZRMMultipleFilesError, ZZRMParseError, ZZRMInvalidFormatError
+from tex2pdf_tools.zerozeroreadme import (
+    ZeroZeroReadMe,
+    ZZRMFileNotFoundError,
+    ZZRMParseError,
+    ZZRMUnsupportedFileError,
+)
 
 unittest.TestCase.maxDiff = None
 
@@ -39,25 +43,27 @@ class Test00README(unittest.TestCase):
         self.assertEqual(set(["fake-file-4.dvi"]), zzrm.keepcomments)
         self.assertEqual(zzrm.spec_version, 1)
 
-    def test_zzrm_v2_01(self) -> None:
+    def test_zzrm_v2_yaml_ignored(self) -> None:
+        # zzrm_v2_01 contains a 00README.yaml, which is no longer supported.
         dir_path = os.path.join(self.fixture_dir, "zzrm_v2_01")
         zzrm = ZeroZeroReadMe(dir_path)
-        self.assertEqual(["fake-file-2.tex", "yaml-5.tex"], zzrm.toplevels)
-        self.assertEqual(set(["fake-file-1.tex"]), zzrm.includes)
-        self.assertEqual(set(["fake-file-3.TEX"]), zzrm.ignores)
-        self.assertEqual(["myfonts1.map", "myfonts2.map"], zzrm.fontmaps)
-        self.assertEqual(set(["fake-file-2.dvi"]), zzrm.landscapes)
-        self.assertEqual(set(["fake-file-4.dvi"]), zzrm.keepcomments)
-        self.assertEqual("pdflatex", zzrm.process.compiler.compiler_string)
-        self.assertEqual(False, zzrm.stamp)
-        self.assertEqual(False, zzrm.nohyperref)
-        self.assertEqual(zzrm.spec_version, 1)
+        self.assertIsNone(zzrm.readme_filename)
+        self.assertIn("00README.yaml", zzrm.ignored_formats)
+        self.assertEqual([], zzrm.toplevels)
 
-    def test_zzrm_v2_syntax_error(self) -> None:
+    def test_zzrm_v2_yaml_ignored_from_file(self) -> None:
+        file_path = os.path.join(self.fixture_dir, "zzrm_v2_01", "00README.yaml")
+        zzrm = ZeroZeroReadMe(file_path)
+        self.assertIsNone(zzrm.readme_filename)
+        self.assertIn("00README.yaml", zzrm.ignored_formats)
+
+    def test_zzrm_v2_syntax_error_ignored(self) -> None:
+        # zzrm_v2_syntax_error contains a 00README.yaml; previously this raised
+        # ZZRMParseError on parsing, now it is silently ignored with a warning.
         dir_path = os.path.join(self.fixture_dir, "zzrm_v2_syntax_error")
-        with pytest.raises(ZZRMParseError) as exc_info:
-            _ = ZeroZeroReadMe(dir_path)
-        assert str(exc_info.value).startswith("Validation error on parsing: ")
+        zzrm = ZeroZeroReadMe(dir_path)
+        self.assertIsNone(zzrm.readme_filename)
+        self.assertIn("00README.yaml", zzrm.ignored_formats)
 
     def test_zzrm_v2_02(self) -> None:
         dir_path = os.path.join(self.fixture_dir, "zzrm_v2_02")
@@ -72,123 +78,34 @@ class Test00README(unittest.TestCase):
         self.assertEqual(False, zzrm.stamp)
         self.assertEqual(zzrm.spec_version, 1)
 
-    def test_zzrm_v2_03(self) -> None:
+    def test_zzrm_v2_toml_ignored(self) -> None:
+        # zzrm_v2_03 contains a 00README.toml, which is no longer supported.
         dir_path = os.path.join(self.fixture_dir, "zzrm_v2_03")
         zzrm = ZeroZeroReadMe(dir_path)
-        self.assertEqual(["fake-file-2.tex", "toml-5.tex"], zzrm.toplevels)
-        self.assertEqual(set(["fake-file-1.tex"]), zzrm.includes)
-        self.assertEqual(set(["fake-file-3.TEX"]), zzrm.ignores)
-        self.assertEqual(["myfonts1.map", "myfonts2.map"], zzrm.fontmaps)
-        self.assertEqual(set(["fake-file-2.dvi"]), zzrm.landscapes)
-        self.assertEqual(set(["fake-file-4.dvi"]), zzrm.keepcomments)
-        self.assertEqual("pdflatex", zzrm.process.compiler.compiler_string)
-        self.assertEqual(False, zzrm.stamp)
-        self.assertEqual(zzrm.spec_version, 1)
+        self.assertIsNone(zzrm.readme_filename)
+        self.assertIn("00README.toml", zzrm.ignored_formats)
 
-    def test_zzrm_v2_04(self) -> None:
+    def test_zzrm_v2_multiple_yaml_ignored(self) -> None:
+        # zzrm_v2_04 contains multiple 00README.yaml files; all ignored.
         dir_path = os.path.join(self.fixture_dir, "zzrm_v2_04")
         zzrm = ZeroZeroReadMe(dir_path)
-        self.assertEqual(["fake-file-2.tex", "yaml1.tex", "yaml2.tex"], zzrm.toplevels)
-        self.assertEqual(set(["fake-file-1.tex"]), zzrm.includes)
-        self.assertEqual(set(["fake-file-3.TEX"]), zzrm.ignores)
-        self.assertEqual(["myfonts1.map", "myfonts2.map"], zzrm.fontmaps)
-        self.assertEqual(set(["fake-file-2.dvi"]), zzrm.landscapes)
-        self.assertEqual(set(["fake-file-4.dvi"]), zzrm.keepcomments)
-        self.assertEqual("pdflatex", zzrm.process.compiler.compiler_string)
-        self.assertEqual(False, zzrm.stamp)
-        self.assertEqual(zzrm.spec_version, 1)
+        self.assertIsNone(zzrm.readme_filename)
+        self.assertTrue(any(f.endswith(".yaml") for f in zzrm.ignored_formats))
 
     def test_zzrm_v2_05(self) -> None:
+        # zzrm_v2_05 has 00README.json, .yaml, and .toml. With the new policy,
+        # the .yaml and .toml are ignored; the .json fixture has a schema
+        # mismatch (legacy fontmaps shape) so parsing it raises.
         dir_path = os.path.join(self.fixture_dir, "zzrm_v2_05")
-        with pytest.raises(ZZRMMultipleFilesError):
+        with pytest.raises(ZZRMParseError):
             _ = ZeroZeroReadMe(dir_path)
 
-    def test_zzrm_out_yaml(self) -> None:
-        dir_path = os.path.join(self.fixture_dir, "zzrm_v1_01")
-        zzrm = ZeroZeroReadMe(dir_path)
-        sio = io.StringIO()
-        zzrm.to_yaml(sio)
-        sio.flush()
-        sio.seek(0)
-        data = sio.read()
-        expected = """comment: |-
-  This is the specification file for processing source files for individual arXiv submissions.
-  Details on the specification are at https://info.arxiv.org/help/00README.html
-process:
-  fontmaps:
-  - myfonts1.map
-  - myfonts2.map
-sources:
-- filename: fake-file-1.tex
-  usage: include
-- filename: fake-file-2.tex
-  usage: toplevel
-- filename: fake-file-3.TEX
-  usage: ignore
-- filename: fake-file-2.dvi
-  orientation: landscape
-- filename: fake-file-4.dvi
-  keep_comments: true
-- filename: fake-file-5.tex
-  usage: toplevel
-stamp: false
-spec_version: 1
-"""
-        self.assertEqual(expected, data)
-
-    def test_zzrm_out_yaml_no_default_comment(self) -> None:
-        dir_path = os.path.join(self.fixture_dir, "zzrm_v1_01")
-        zzrm = ZeroZeroReadMe(dir_path)
-        sio = io.StringIO()
-        zzrm.to_yaml(sio, add_default_comment=False)
-        sio.flush()
-        sio.seek(0)
-        data = sio.read()
-        expected = """process:
-  fontmaps:
-  - myfonts1.map
-  - myfonts2.map
-sources:
-- filename: fake-file-1.tex
-  usage: include
-- filename: fake-file-2.tex
-  usage: toplevel
-- filename: fake-file-3.TEX
-  usage: ignore
-- filename: fake-file-2.dvi
-  orientation: landscape
-- filename: fake-file-4.dvi
-  keep_comments: true
-- filename: fake-file-5.tex
-  usage: toplevel
-stamp: false
-spec_version: 1
-"""
-        self.assertEqual(expected, data)
-
-    def test_zzrm_out_toml(self) -> None:
-        dir_path = os.path.join(self.fixture_dir, "zzrm_v1_01")
-        zzrm = ZeroZeroReadMe(dir_path)
-        data = zzrm.to_toml()
-        expected = """comment = "This is the specification file for processing source files for individual arXiv submissions.\\nDetails on the specification are at https://info.arxiv.org/help/00README.html"
-sources = [
-    { filename = "fake-file-1.tex", usage = "include" },
-    { filename = "fake-file-2.tex", usage = "toplevel" },
-    { filename = "fake-file-3.TEX", usage = "ignore" },
-    { filename = "fake-file-2.dvi", orientation = "landscape" },
-    { filename = "fake-file-4.dvi", keep_comments = true },
-    { filename = "fake-file-5.tex", usage = "toplevel" },
-]
-stamp = false
-spec_version = 1
-
-[process]
-fontmaps = [
-    "myfonts1.map",
-    "myfonts2.map",
-]
-"""
-        self.assertEqual(expected, data)
+    def test_zzrm_v2_unsupported_extension_raises(self) -> None:
+        # init_from_file with a non-00README extension still raises.
+        file_path = os.path.join(self.fixture_dir, "zzrm_v1_01", "00README.XXX")
+        bad_path = file_path + ".bogus"
+        with pytest.raises((ZZRMUnsupportedFileError, ZZRMFileNotFoundError)):
+            _ = ZeroZeroReadMe(bad_path)
 
     def test_zzrm_out_json(self) -> None:
         dir_path = os.path.join(self.fixture_dir, "zzrm_v1_01")
@@ -263,27 +180,6 @@ fontmaps = [
         dir_path = os.path.join(self.fixture_dir, "zzrm_pdfetex")
         zzrm = ZeroZeroReadMe(dir_path)
         self.assertEqual("pdftex", zzrm.process.compiler.compiler_string)
-
-    def test_yaml_dump(self) -> None:
-        dir_path = os.path.join(self.fixture_dir, "zzrm_yaml_dump")
-        zzrm = ZeroZeroReadMe(dir_path)
-        sio = io.StringIO()
-        zzrm.to_yaml(sio)
-        sio.flush()
-        sio.seek(0)
-        data = sio.read()
-        expected = """process:
-  bibliography:
-    - pre_generated: false
-    - process: bibtex
-  index:
-    - pre_generated: false
-    - process: makeindex
-sources:
-- filename: fake-file-1.tex
-  usage: toplevel
-stamp: false
-"""
 
     def test_zzrm_tl_version_current(self) -> None:
         dir_path = os.path.join(self.fixture_dir, "zzrm_v2_current")

--- a/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
@@ -1779,6 +1779,34 @@ def _dump_nodes(nodes: dict[str, ParsedTeXFile]) -> None:
         logger.debug("... ... used_other_files = %s", n.used_other_files)
 
 
+# Extensions that were once accepted as 00README V2 input but are no longer
+# supported. Kept here (rather than imported from tex2pdf_tools.zerozeroreadme)
+# to avoid a circular import: zerozeroreadme already imports from preflight.
+_UNSUPPORTED_ZZRM_EXTS: tuple[str, ...] = (".yml", ".yaml", ".jsn", ".ndjson", ".toml")
+
+
+def _check_unsupported_zzrm_formats(rundir: str) -> list[TeXFileIssue]:
+    """Detect 00README files in formats we no longer accept."""
+    issues: list[TeXFileIssue] = []
+    try:
+        entries = sorted(os.listdir(rundir))
+    except OSError:
+        return issues
+    for filename in entries:
+        stem, ext = os.path.splitext(filename)
+        if stem.upper() != "00README":
+            continue
+        if ext.lower() in _UNSUPPORTED_ZZRM_EXTS:
+            issues.append(
+                TeXFileIssue(
+                    IssueType.unsupported_zzrm_format,
+                    f"00README format {ext} is no longer supported; only .json is accepted",
+                    filename=filename,
+                )
+            )
+    return issues
+
+
 def _generate_preflight_response_dict(rundir: str) -> PreflightResponse:
     """Parse submission and generated preflight response as dictionary."""
     # parse files
@@ -1794,6 +1822,7 @@ def _generate_preflight_response_dict(rundir: str) -> PreflightResponse:
 
     try:
         n, anc_files, maybe_files, image_files, warning_issues = parse_dir(rundir)
+        warning_issues.extend(_check_unsupported_zzrm_formats(rundir))
         tests_succeeded = True
         error_msg = ""
     except CheckPreflightException as e:

--- a/tex2pdf-tools/tex2pdf_tools/preflight/models.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/models.py
@@ -96,6 +96,7 @@ class IssueType(str, Enum):
     pdf_not_pdf = "pdf_not_pdf"
     graphics_driver_option = "graphics_driver_option"
     graphics_driver_unsupported = "graphics_driver_unsupported"
+    unsupported_zzrm_format = "unsupported_zzrm_format"
     other = "other"
 
 

--- a/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/zerozeroreadme/__init__.py
@@ -1,17 +1,14 @@
 """00README file parsing and handling."""
 
 import json
+import logging
 import os
 import typing
 from collections import OrderedDict
 from enum import Enum
 from json import JSONDecodeError
 
-import toml
-import tomli_w
 from pydantic import BaseModel, ConfigDict, ValidationError
-from ruamel.yaml import YAML, MappingNode, ScalarNode
-from ruamel.yaml.representer import RoundTripRepresenter
 
 from ..preflight import (
     CURRENT_TEXLIVE_VERSION,
@@ -40,28 +37,20 @@ Details on the specification are at https://info.arxiv.org/help/00README.html"""
 
 # 00README extensions
 ZZRM_V1_EXTS: list[str] = [".xxx"]
-ZZRM_V2_EXTS: list[str] = [".yml", ".yaml", ".json", ".jsn", ".ndjson", ".toml"]
+ZZRM_V2_EXTS: list[str] = [".json"]
+# Previously supported V2 extensions that we now ignore (with a warning).
+ZZRM_V2_DEPRECATED_EXTS: list[str] = [".yml", ".yaml", ".jsn", ".ndjson", ".toml"]
 ZZRM_EXTS: list[str] = ZZRM_V2_EXTS + ZZRM_V1_EXTS
 DEFAULT_EXT = ".json"
 DEFAULT_FORMAT = "json"
+
+logger = logging.getLogger("zerozeroreadme")
 
 # We default to pdflatex
 DEFAULT_ENGINE_TYPE: EngineType = EngineType.tex
 DEFAULT_LANGUAGE_TYPE: LanguageType = LanguageType.latex
 DEFAULT_OUTPUT_TYPE: OutputType = OutputType.pdf
 DEFAULT_POSTPROCESS_TYPE: PostProcessType = PostProcessType.none
-
-
-def yaml_repr_str(dumper: RoundTripRepresenter, data: str) -> ScalarNode:
-    """Convert string to yaml representation."""
-    if "\n" in data:
-        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
-    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
-
-
-def yaml_repr_ordered_dict(dumper: RoundTripRepresenter, data: OrderedDict) -> MappingNode:
-    """Convert ordered dict to yaml representation."""
-    return dumper.represent_mapping("tag:yaml.org,2002:map", dict(data))
 
 
 def strip_to_basename(path: str, extent: None | str = None) -> str:
@@ -180,6 +169,7 @@ class ZeroZeroReadMe:
         self.nohyperref: bool | None = None
         self.texlive_version: int | None = None
         self.comment: str | None = None
+        self.ignored_formats: list[str] = []
         if dir_or_file is None:
             return
         elif os.path.isdir(dir_or_file):
@@ -228,10 +218,15 @@ class ZeroZeroReadMe:
         stem, ext = os.path.splitext(os.path.basename(file))
         if stem.upper() != "00README":
             raise ZZRMUnsupportedFileError(f"File {file} must start with 00README (case-insensitive)")
-        if ext.lower() in ZZRM_V1_EXTS:
+        ext_lower = ext.lower()
+        if ext_lower in ZZRM_V1_EXTS:
             self._fetch_00readme_data(file, 1)
-        elif ext.lower() in ZZRM_V2_EXTS:
+        elif ext_lower in ZZRM_V2_EXTS:
             self._fetch_00readme_data(file, 2)
+        elif ext_lower in ZZRM_V2_DEPRECATED_EXTS:
+            basename = os.path.basename(file)
+            logger.warning("Ignoring unsupported 00README format %s; only .json is accepted", basename)
+            self.ignored_formats.append(basename)
         else:
             raise ZZRMUnsupportedFileError(f"Unsupported file extension {ext}")
 
@@ -260,10 +255,14 @@ class ZeroZeroReadMe:
             (stem, ext) = os.path.splitext(filename)
             if stem.upper() != "00README":
                 continue
-            if ext.lower() in ZZRM_V1_EXTS:
+            ext_lower = ext.lower()
+            if ext_lower in ZZRM_V1_EXTS:
                 zzrms_v1.append(filename)
-            elif ext.lower() in ZZRM_V2_EXTS:
+            elif ext_lower in ZZRM_V2_EXTS:
                 zzrms_v2.append(filename)
+            elif ext_lower in ZZRM_V2_DEPRECATED_EXTS:
+                logger.warning("Ignoring unsupported 00README format %s; only .json is accepted", filename)
+                self.ignored_formats.append(filename)
             else:
                 # ignore files that are named 00readme.SOMETHING but don't match
                 # the correct extensions
@@ -364,26 +363,11 @@ class ZeroZeroReadMe:
                     self.nohyperref = True
 
     def _fetch_00readme_v2(self, data: str, ext: str) -> None:
-        """Read and parse 00README.XXX file, v2."""
-        zzrm = None
-        match ext:
-            case ".yml" | ".yaml":
-                try:
-                    loader = YAML()
-                    zzrm = loader.load(data)
-                except Exception as e:
-                    # ruamel.yaml documentation is just **silent** about what exceptions it throws, how bad.
-                    raise ZZRMInvalidFormatError("Invalid file format") from e
-            case ".json" | ".jsn" | ".ndjson":
-                try:
-                    zzrm = json.loads(data)
-                except JSONDecodeError as e:
-                    raise ZZRMInvalidFormatError("Invalid file format") from e
-            case ".toml":
-                try:
-                    zzrm = toml.loads(data)
-                except toml.TomlDecodeError as e:
-                    raise ZZRMInvalidFormatError("Invalid file format") from e
+        """Read and parse 00README.json file, v2."""
+        try:
+            zzrm = json.loads(data)
+        except JSONDecodeError as e:
+            raise ZZRMInvalidFormatError("Invalid file format") from e
 
         if zzrm:
             self.filetype_version = 2
@@ -650,24 +634,6 @@ class ZeroZeroReadMe:
                 assembly.append(strip_to_basename(fn, ".pdf"))
         return assembly
 
-    def to_yaml(self, output: typing.TextIO, add_default_comment: bool = True) -> typing.TextIO:
-        """Provide YAML representation of ZZRM."""
-        yaml = YAML()
-        yaml.representer.add_representer(str, yaml_repr_str)
-        yaml.representer.add_representer(OrderedDict, yaml_repr_ordered_dict)
-        yaml.representer.add_representer(EngineType, yaml_repr_str)
-        yaml.representer.add_representer(LanguageType, yaml_repr_str)
-        yaml.representer.add_representer(OutputType, yaml_repr_str)
-        yaml.representer.add_representer(PostProcessType, yaml_repr_str)
-        yaml.representer.add_representer(FileUsageType, yaml_repr_str)
-        yaml.representer.add_representer(OrientationType, yaml_repr_str)
-        yaml.dump(self.to_dict(add_default_comment), output)
-        return output
-
     def to_json(self, indent: int | None = 4, add_default_comment: bool = True) -> str:
         """Provide JSON representation of ZZRM."""
         return json.dumps(self.to_dict(add_default_comment), indent=indent)
-
-    def to_toml(self, add_default_comment: bool = True) -> str:
-        """Provide TOML representation of ZZRM."""
-        return tomli_w.dumps(self.to_dict(add_default_comment))


### PR DESCRIPTION
- change preflight to warn on presence of unsupported files, but read only json
- change testing/local dev to always use the tex2pdf-tools from current state/dir
- change tex2pdf-service to include the json version of zzrm as text