### PR TITLE
[preflight] add entry-point plugin mechanism for QA checks

### DIFF
--- a/tex2pdf-tools/tests/preflight/test_plugin_checks.py
+++ b/tex2pdf-tools/tests/preflight/test_plugin_checks.py
@@ -1,0 +1,183 @@
+"""Tests for the check-plugin host mechanism.
+
+These exercise discovery/merge, the built-ins-win collision policy, fail-open
+behaviour, and the source-check + suspicious-status wiring -- all *without* a
+real installed plugin, by injecting fakes through the documented test hooks
+(``reset_checks`` / the cached callable lists) and by monkeypatching the
+entry-point enumeration.  The public package ships no heuristics, so with no
+plugin installed every registry is empty and the checks no-op.
+"""
+
+import pytest
+
+import tex2pdf_tools.preflight as preflight
+from tex2pdf_tools.preflight import file_checks, pdf_checks, plugin_api, source_checks
+from tex2pdf_tools.preflight.models import (
+    CheckResult,
+    CheckSeverity,
+    IssueType,
+    PreflightStatusValues,
+    TeXFileIssue,
+)
+from tex2pdf_tools.preflight.plugin_api import CheckSpec
+
+
+@pytest.fixture(autouse=True)
+def _reset_registries():
+    """Reset cached registries before and after each test for isolation."""
+    pdf_checks.reset_checks()
+    file_checks.reset_checks()
+    source_checks.reset_source_checks()
+    yield
+    pdf_checks.reset_checks()
+    file_checks.reset_checks()
+    source_checks.reset_source_checks()
+
+
+class _FakeEP:
+    """Minimal stand-in for importlib.metadata.EntryPoint."""
+
+    def __init__(self, name, obj):
+        self.name = name
+        self._obj = obj
+
+    def load(self):
+        return self._obj
+
+
+def _ok_check(res, severity):
+    return CheckResult(check_passed=True, info="", long_info="", severity=severity, issues=[])
+
+
+# --------------------------------------------------------------------------- #
+# No plugin installed -> empty registries, everything no-ops
+# --------------------------------------------------------------------------- #
+
+
+def test_builtin_only_registries(monkeypatch):
+    monkeypatch.setattr(plugin_api, "_load_entry_points", lambda group: [])
+    pdf_checks._ensure_loaded()
+    file_checks._ensure_loaded()
+    assert set(pdf_checks.PDF_CHECKS) == {"javascript"}
+    assert set(file_checks.FILE_CHECKS) == {"no-exe", "image-sizes", "pdf-are-pdf"}
+
+
+def test_source_checks_noop_without_plugins(monkeypatch):
+    monkeypatch.setattr(plugin_api, "_load_entry_points", lambda group: [])
+    assert source_checks.run_source_file_checks("main.tex", b"hello") == []
+    assert source_checks.run_source_tree_checks([("main.tex", b"hello")]) == []
+
+
+# --------------------------------------------------------------------------- #
+# Discovery + merge semantics
+# --------------------------------------------------------------------------- #
+
+
+def test_plugin_pdf_check_is_discovered(monkeypatch):
+    def provider():
+        return CheckSpec("fake-pdf", _ok_check, CheckSeverity.warning)
+
+    monkeypatch.setattr(
+        plugin_api,
+        "_load_entry_points",
+        lambda group: [_FakeEP("fp", provider)] if group == plugin_api.PDF_CHECKS_GROUP else [],
+    )
+    pdf_checks._ensure_loaded()
+    assert "javascript" in pdf_checks.PDF_CHECKS  # built-in still present
+    assert "fake-pdf" in pdf_checks.PDF_CHECKS  # discovered
+
+
+def test_builtins_win_on_name_collision(monkeypatch):
+    """A plugin re-registering a built-in name is skipped, not honoured."""
+    sentinel = object()
+
+    def provider():
+        return CheckSpec("javascript", sentinel, CheckSeverity.error)
+
+    monkeypatch.setattr(
+        plugin_api,
+        "_load_entry_points",
+        lambda group: [_FakeEP("dup", provider)] if group == plugin_api.PDF_CHECKS_GROUP else [],
+    )
+    pdf_checks._ensure_loaded()
+    assert pdf_checks.PDF_CHECKS["javascript"][0] is not sentinel  # built-in kept
+
+
+def test_merge_is_fail_open(monkeypatch):
+    """A broken provider is logged and skipped; good ones still register."""
+
+    def boom():
+        raise RuntimeError("broken plugin")
+
+    def good():
+        return CheckSpec("good", _ok_check, CheckSeverity.warning)
+
+    monkeypatch.setattr(
+        plugin_api, "_load_entry_points", lambda group: [_FakeEP("bad", boom), _FakeEP("good", good)]
+    )
+    registry: dict = {}
+    plugin_api.merge_check_specs("any-group", registry)  # must not raise
+    assert "good" in registry
+    assert "bad" not in registry
+
+
+# --------------------------------------------------------------------------- #
+# Source-check wiring -> suspicious status (opt-in) + arbitrary key round-trip
+# --------------------------------------------------------------------------- #
+
+
+def _flagging_source_check(filename, data):
+    # Emits a plugin-private issue key that is NOT a member of IssueType.
+    return [TeXFileIssue("obfuscated_source", "looks obfuscated", filename)]
+
+
+def _write_min_tex(tmp_path):
+    (tmp_path / "main.tex").write_text(
+        r"\documentclass{article}" + "\n" + r"\begin{document}" + "\nhello\n" + r"\end{document}" + "\n"
+    )
+
+
+def test_suspicious_status_when_flag_on(tmp_path, monkeypatch):
+    _write_min_tex(tmp_path)
+    monkeypatch.setattr(source_checks, "_file_checks", [_flagging_source_check])
+    monkeypatch.setattr(preflight, "SOURCE_CHECK_SETS_SUSPICIOUS", True)
+
+    pf = preflight.generate_preflight_response(str(tmp_path))
+    assert pf.status.key == PreflightStatusValues.suspicious
+    keys = [iss.key for tf in pf.tex_files for iss in tf.issues]
+    assert "obfuscated_source" in keys
+    # The plugin-private string key round-trips through JSON serialization.
+    js = preflight.generate_preflight_response(str(tmp_path), json=True)
+    assert "obfuscated_source" in js
+
+
+def test_no_suspicious_when_flag_off(tmp_path, monkeypatch):
+    _write_min_tex(tmp_path)
+    monkeypatch.setattr(source_checks, "_file_checks", [_flagging_source_check])
+    monkeypatch.setattr(preflight, "SOURCE_CHECK_SETS_SUSPICIOUS", False)
+
+    pf = preflight.generate_preflight_response(str(tmp_path))
+    # Issue is still surfaced, but status stays success (opt-in flag is off).
+    assert pf.status.key == PreflightStatusValues.success
+    keys = [iss.key for tf in pf.tex_files for iss in tf.issues]
+    assert "obfuscated_source" in keys
+
+
+def test_source_plugin_failopen_does_not_break_preflight(tmp_path, monkeypatch):
+    _write_min_tex(tmp_path)
+
+    def boom(filename, data):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(source_checks, "_file_checks", [boom])
+    monkeypatch.setattr(preflight, "SOURCE_CHECK_SETS_SUSPICIOUS", True)
+
+    pf = preflight.generate_preflight_response(str(tmp_path))
+    assert pf.status.key == PreflightStatusValues.success  # crash swallowed, no flag
+
+
+def test_builtin_issue_key_still_enum():
+    """Built-in checks keep emitting IssueType members (so .key.value works)."""
+    issue = TeXFileIssue(IssueType.oversized_image, "big", "fig.png")
+    assert issue.key == IssueType.oversized_image
+    assert issue.key.value == "oversized_image"

--- a/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/__init__.py
@@ -18,7 +18,7 @@ from pprint import pformat
 
 from pydantic import BaseModel, Field
 
-from .feature_flags import ENABLE_LUALATEX
+from .feature_flags import ENABLE_LUALATEX, SOURCE_CHECK_SETS_SUSPICIOUS
 from .file_checks import run_checks as run_file_checks
 from .images import collect_image_info
 from .models import (
@@ -57,6 +57,7 @@ from .pdf_checks import run_checks as run_pdf_checks
 
 # tell ruff to not complain, I don't want to add __all__ entries
 from .report import PreflightReport  # noqa
+from .source_checks import run_source_file_checks, run_source_tree_checks
 
 MODULE_PATH = os.path.dirname(__file__)
 
@@ -138,6 +139,10 @@ class ParsedTeXFile(BaseModel):
 
     filename: str
     _data: bytes = b""  # content of files is read in bytes
+    # Non-serialized side channel: set True when a per-file source-check plugin
+    # produced an issue for this file, so the overall status logic can decide
+    # "suspicious" without inspecting the (plugin-private) issue keys.
+    _source_checks_flagged: bool = False
     _graphicspath: list[list[str]] = []
     _uses_bibliography: bool = False
     _uses_bbl_file_type: set[BblType] = set()
@@ -1024,6 +1029,12 @@ def parse_file(basedir: str, filename: str, only_image: bool = False) -> ParsedT
     n.detect_included_files(only_images=only_image)
     logger.debug("parse_file: starting detect_language")
     n.detect_language()
+    # Run any per-file source-check plugins (e.g. obfuscated-source detection).
+    # No-op when no plugin is installed.
+    src_issues = run_source_file_checks(n.filename, n._data)
+    if src_issues:
+        n.issues.extend(src_issues)
+        n._source_checks_flagged = True
     logger.debug("parse_file: finished parsing")
 
     return n
@@ -1835,7 +1846,11 @@ def _generate_preflight_response_dict(rundir: str) -> PreflightResponse:
         maybe_files = []
         status = PreflightStatus(key=PreflightStatusValues.error, info=error_msg)
     elif isinstance(n, ToplevelFile):
-        # pdf only submission, we received the toplevel file already
+        # pdf only submission, we received the toplevel file already.
+        # Surface any PDF-check warnings (e.g. hidden-text/glyph in warning mode)
+        # collected by parse_dir; these are informational and do not by themselves
+        # make the submission "suspicious".
+        n.issues.extend(warning_issues)
         toplevel_files = {n.filename: n}
         nodes = {}
         status = PreflightStatus(key=PreflightStatusValues.success)
@@ -1878,8 +1893,35 @@ def _generate_preflight_response_dict(rundir: str) -> PreflightResponse:
             if toplevel_files and warning_issues:
                 first_tlf = next(iter(toplevel_files.values()))
                 first_tlf.issues.extend(warning_issues)
-            # TODO check for suspicious status!
-            status = PreflightStatus(key=PreflightStatusValues.success)
+            # Run whole-tree source-check plugins (e.g. a pattern that spans several
+            # files, where per-file signals alone are insufficient).  No-op when no
+            # plugin is installed.
+            tree_source_flagged = False
+            for tlf in toplevel_files:
+                tl_n = nodes[tlf]
+                tree_names = list(dict.fromkeys([tlf, *tl_n.recursive_collect_files(FileType.tex)]))
+                tree_files = [(nm, nodes[nm]._data) for nm in tree_names if nm in nodes]
+                for issue in run_source_tree_checks(tree_files):
+                    n_ = nodes.get(issue.filename) if issue.filename is not None else None
+                    if n_ is None:
+                        continue
+                    tree_source_flagged = True
+                    # Dedup: skip if the same (file, key) issue is already attached
+                    # (e.g. a per-file source check already flagged this file).
+                    if not any(i.key == issue.key for i in n_.issues):
+                        n_.issues.append(issue)
+            # A source-check plugin flagging a file makes the submission "suspicious"
+            # (opt-in via PREFLIGHT_SOURCE_SUSPICIOUS).  Decided from the private side
+            # channel / tree results, never from a specific (plugin-private) issue key.
+            if SOURCE_CHECK_SETS_SUSPICIOUS and (
+                tree_source_flagged or any(nd._source_checks_flagged for nd in nodes.values())
+            ):
+                status = PreflightStatus(
+                    key=PreflightStatusValues.suspicious,
+                    info="source check flagged one or more files",
+                )
+            else:
+                status = PreflightStatus(key=PreflightStatusValues.success)
     return PreflightResponse(
         status=status,
         detected_toplevel_files=[tl for tl in toplevel_files.values()],

--- a/tex2pdf-tools/tex2pdf_tools/preflight/feature_flags.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/feature_flags.py
@@ -15,3 +15,10 @@ ENABLE_LUALATEX: bool = env_flag("ENABLE_LUALATEX")
 
 # Enable JavaScript checks
 ENABLE_JS_CHECKS: bool = env_flag("ENABLE_JS_CHECKS")
+
+# When a source-check plugin flags a file (e.g. obfuscated source), also flip the
+# overall preflight status to "suspicious".  The per-file issues are attached
+# regardless; this only controls the top-level status surfacing.  Opt-in
+# (default False), consistent with the other PREFLIGHT_* flags -- set
+# PREFLIGHT_SOURCE_SUSPICIOUS=1 in the deployment env to enable.
+SOURCE_CHECK_SETS_SUSPICIOUS: bool = env_flag("PREFLIGHT_SOURCE_SUSPICIOUS")

--- a/tex2pdf-tools/tex2pdf_tools/preflight/file_checks.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/file_checks.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 
 from .images import collect_image_info
 from .models import CheckResult, CheckSeverity, ImageInfo, IssueType, TeXFileIssue, logger
+from .plugin_api import FILE_CHECKS_GROUP, merge_check_specs, safe_call
 
 # Default threshold for oversized images (in megapixels)
 # Assuming 600dpi on a full page A4 paper we would have
@@ -146,11 +147,36 @@ def pdf_are_pdf(
     )
 
 
-FILE_CHECKS: dict[str, tuple[Callable[[list[str], str, dict, CheckSeverity], CheckResult], CheckSeverity]] = {
-    "no-exe": (check_no_exe, CheckSeverity.error),
-    "image-sizes": (check_image_sizes, CheckSeverity.warning),
-    "pdf-are-pdf": (pdf_are_pdf, CheckSeverity.error),
-}
+# Registry of available file checks: name -> (callable, default severity).
+# Populated in place by ``_ensure_loaded()`` from the built-in checks plus any
+# checks discovered via the ``tex2pdf_tools.preflight.file_checks`` entry-point
+# group.  Kept as a single module-level object (never rebound) so that test
+# ``monkeypatch.setitem(file_checks.FILE_CHECKS, ...)`` keeps working.
+FILE_CHECKS: dict[str, tuple[Callable[[list[str], str, dict, CheckSeverity], CheckResult], CheckSeverity]] = {}
+_loaded = False
+
+
+def _ensure_loaded() -> None:
+    """Populate ``FILE_CHECKS`` once: built-ins first (they win), then plugins."""
+    global _loaded  # noqa: PLW0603
+    if _loaded:
+        return
+    builtins = {
+        "no-exe": (check_no_exe, CheckSeverity.error),
+        "image-sizes": (check_image_sizes, CheckSeverity.warning),
+        "pdf-are-pdf": (pdf_are_pdf, CheckSeverity.error),
+    }
+    for name, spec in builtins.items():
+        FILE_CHECKS.setdefault(name, spec)
+    merge_check_specs(FILE_CHECKS_GROUP, FILE_CHECKS)
+    _loaded = True
+
+
+def reset_checks() -> None:
+    """Test hook: clear the registry and force re-discovery on next use."""
+    global _loaded  # noqa: PLW0603
+    FILE_CHECKS.clear()
+    _loaded = False
 
 
 def run_checks(
@@ -169,6 +195,7 @@ def run_checks(
         - the list of **failed** CheckResults with severity=error
         - the list of **failed** CheckResults with severity=warning
     """
+    _ensure_loaded()
     error_results: list[CheckResult] = []
     warning_results: list[CheckResult] = []
 
@@ -182,7 +209,10 @@ def run_checks(
         if check in FILE_CHECKS:
             func = FILE_CHECKS[check][0]
             severity = FILE_CHECKS[check][1]
-            res = func(files, rundir, extra, severity)
+            # Fail-open: a check raising must never abort preflight.
+            res = safe_call(func, files, rundir, extra, severity, label=f"file-check:{check}")
+            if res is None:
+                continue
             if not res.check_passed:
                 if res.severity == CheckSeverity.error:
                     error_results.append(res)

--- a/tex2pdf-tools/tex2pdf_tools/preflight/models.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/models.py
@@ -101,14 +101,23 @@ class IssueType(str, Enum):
 
 
 class TeXFileIssue(BaseModel):
-    """Specification of Issue in a file."""
+    """Specification of Issue in a file.
 
-    key: IssueType
+    ``key`` is widened to ``IssueType | str`` so that check *plugins* (which live
+    outside this public package) can emit their own issue-type identifiers
+    without those identifiers having to be enumerated here.  Built-in checks keep
+    using the ``IssueType`` enum (so ``issue.key.value`` keeps working); a
+    plugin-supplied string that is not a known member is accepted as-is.  Both
+    serialize to the same plain string on the wire (Pydantic dumps the enum's
+    value), so downstream JSON consumers see a uniform string ``key``.
+    """
+
+    key: IssueType | str
     info: str
     # line: int
     filename: str | None = None
 
-    def __init__(self, key: IssueType, info: str, filename: str | None = None, **kwargs: typing.Any) -> None:
+    def __init__(self, key: IssueType | str, info: str, filename: str | None = None, **kwargs: typing.Any) -> None:
         """Override __init__ to be able to use positional parameters."""
         super().__init__(key=key, info=info, filename=filename, **kwargs)
 

--- a/tex2pdf-tools/tex2pdf_tools/preflight/pdf_checks.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/pdf_checks.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from .models import CheckResult, CheckSeverity, logger
+from .plugin_api import PDF_CHECKS_GROUP, merge_check_specs, safe_call
 
 
 def get_pdf_info(pdf: str) -> dict[str, Any]:
@@ -34,7 +35,7 @@ def get_pdf_info(pdf: str) -> dict[str, Any]:
         # ("pdfimages_list", ["pdfimages", "-list", str(pdf_path)]),
     ]
 
-    results = {}
+    results: dict[str, Any] = {}
 
     for key, cmd in cmds:
         try:
@@ -50,6 +51,10 @@ def get_pdf_info(pdf: str) -> dict[str, Any]:
         except Exception as e:
             logger.error(f"Error running {' '.join(cmd)}: {e}")
             results[key] = {"error": str(e), "returncode": -1}
+
+    # Make the path available to checks that need to open the PDF directly
+    # (e.g. PDF-check plugins that parse the PDF rather than read pdfinfo output).
+    results["pdf_path"] = str(pdf_path)
 
     return results
 
@@ -75,9 +80,30 @@ def check_javascript(res: dict, severity: CheckSeverity) -> CheckResult:
     return CheckResult(check_passed=True, info="", long_info="", severity=severity, issues=[])
 
 
-PDF_CHECKS: dict[str, tuple[Callable[[dict, CheckSeverity], CheckResult], CheckSeverity]] = {
-    "javascript": (check_javascript, CheckSeverity.warning),
-}
+# Registry of available PDF checks: name -> (callable, default severity).
+# Populated in place by ``_ensure_loaded()`` from the built-in checks plus any
+# checks discovered via the ``tex2pdf_tools.preflight.pdf_checks`` entry-point
+# group.  Kept as a single module-level object (never rebound) so that test
+# ``monkeypatch.setitem(pdf_checks.PDF_CHECKS, ...)`` keeps working.
+PDF_CHECKS: dict[str, tuple[Callable[[dict, CheckSeverity], CheckResult], CheckSeverity]] = {}
+_loaded = False
+
+
+def _ensure_loaded() -> None:
+    """Populate ``PDF_CHECKS`` once: built-ins first (they win), then plugins."""
+    global _loaded  # noqa: PLW0603
+    if _loaded:
+        return
+    PDF_CHECKS.setdefault("javascript", (check_javascript, CheckSeverity.warning))
+    merge_check_specs(PDF_CHECKS_GROUP, PDF_CHECKS)
+    _loaded = True
+
+
+def reset_checks() -> None:
+    """Test hook: clear the registry and force re-discovery on next use."""
+    global _loaded  # noqa: PLW0603
+    PDF_CHECKS.clear()
+    _loaded = False
 
 
 def run_checks(pdf: str, checks: list[str] | str) -> tuple[bool, list[CheckResult], list[CheckResult]]:
@@ -92,6 +118,7 @@ def run_checks(pdf: str, checks: list[str] | str) -> tuple[bool, list[CheckResul
         - the list of **failed** CheckResults with severity=error
         - the list of **failed** CheckResults with severity=warning
     """
+    _ensure_loaded()
     pdf_info = get_pdf_info(pdf)
     error_results: list[CheckResult] = []
     warning_results: list[CheckResult] = []
@@ -104,7 +131,10 @@ def run_checks(pdf: str, checks: list[str] | str) -> tuple[bool, list[CheckResul
         if check in PDF_CHECKS:
             func = PDF_CHECKS[check][0]
             severity = PDF_CHECKS[check][1]
-            res = func(pdf_info, severity)
+            # Fail-open: a check raising must never abort PDF production.
+            res = safe_call(func, pdf_info, severity, label=f"pdf-check:{check}")
+            if res is None:
+                continue
             if not res.check_passed:
                 if res.severity == CheckSeverity.error:
                     error_results.append(res)

--- a/tex2pdf-tools/tex2pdf_tools/preflight/plugin_api.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/plugin_api.py
@@ -1,0 +1,101 @@
+"""Plugin discovery for preflight QA checks.
+
+This module is the *host* side of a small plugin system.  Check implementations
+are discovered at runtime via Python entry points (:mod:`importlib.metadata`).
+**No check heuristics live in the public package** -- only the contract
+(:class:`CheckSpec`), the discovery/merge helpers, and a fail-open invocation
+wrapper.  When no plugin is installed every entry-point group resolves empty and
+the corresponding checks simply do not run.
+
+Entry-point groups (the public contract with plugins):
+
+  * ``tex2pdf_tools.preflight.file_checks``        -> ``provider() -> CheckSpec``
+  * ``tex2pdf_tools.preflight.pdf_checks``         -> ``provider() -> CheckSpec``
+  * ``tex2pdf_tools.preflight.source_file_checks`` -> ``fn(filename, data) -> list[TeXFileIssue]``
+  * ``tex2pdf_tools.preflight.source_tree_checks`` -> ``fn(tree_files) -> list[TeXFileIssue]``
+
+File/PDF check entry points resolve to a zero-argument *provider* returning a
+:class:`CheckSpec`; using a provider (rather than the bare function) lets the
+plugin decide its severity lazily -- e.g. from its own feature flags -- at load
+time.  Source-check entry points resolve directly to the detection callable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib.metadata import entry_points
+from typing import Any
+
+from .models import CheckSeverity, logger
+
+# Entry-point group names.
+FILE_CHECKS_GROUP = "tex2pdf_tools.preflight.file_checks"
+PDF_CHECKS_GROUP = "tex2pdf_tools.preflight.pdf_checks"
+SOURCE_FILE_CHECKS_GROUP = "tex2pdf_tools.preflight.source_file_checks"
+SOURCE_TREE_CHECKS_GROUP = "tex2pdf_tools.preflight.source_tree_checks"
+
+
+@dataclass
+class CheckSpec:
+    """What a file/pdf check plugin provides: a name, the callable, and a severity."""
+
+    name: str
+    func: Callable[..., Any]
+    severity: CheckSeverity = CheckSeverity.error
+
+
+def _load_entry_points(group: str) -> list:
+    try:
+        return list(entry_points(group=group))
+    except Exception as e:  # pragma: no cover - importlib edge cases
+        logger.warning("Could not enumerate entry points for group %s: %s", group, e)
+        return []
+
+
+def merge_check_specs(group: str, registry: dict[str, tuple[Callable, CheckSeverity]]) -> None:
+    """Discover check plugins in ``group`` and merge them into ``registry`` in place.
+
+    Built-ins win: a discovered check whose name is already present is logged and
+    skipped -- it never overwrites a built-in or an earlier plugin.  Both
+    discovery and provider invocation are fail-open: a broken plugin is logged
+    and skipped, never raised.
+    """
+    for ep in _load_entry_points(group):
+        try:
+            provider = ep.load()
+            spec = provider()
+        except Exception as e:
+            logger.warning("Failed to load check plugin %r from group %s: %s", ep.name, group, e)
+            continue
+        if not isinstance(spec, CheckSpec):
+            logger.warning("Check plugin %r did not return a CheckSpec; skipping", ep.name)
+            continue
+        if spec.name in registry:
+            logger.warning("Duplicate check name %r from plugin %r; skipping (built-ins win)", spec.name, ep.name)
+            continue
+        registry[spec.name] = (spec.func, spec.severity)
+
+
+def load_callables(group: str) -> list[Callable]:
+    """Discover source-check plugins in ``group`` (each entry point -> a callable).
+
+    Fail-open: a plugin that cannot be loaded is logged and skipped.
+    """
+    out: list[Callable] = []
+    for ep in _load_entry_points(group):
+        try:
+            out.append(ep.load())
+        except Exception as e:
+            logger.warning("Failed to load source-check plugin %r from group %s: %s", ep.name, group, e)
+    return out
+
+
+def safe_call(func: Callable, *args: Any, default: Any = None, label: str = "") -> Any:
+    """Invoke a plugin callable, fail-open: log and return ``default`` on any error."""
+    try:
+        return func(*args)
+    except Exception as e:
+        name = label or getattr(func, "__name__", "") or repr(func)
+        logger.warning("Check plugin %s raised during invocation: %s", name, e)
+        return default

--- a/tex2pdf-tools/tex2pdf_tools/preflight/source_checks.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/source_checks.py
@@ -1,0 +1,64 @@
+"""Host-side runners for source (TeX) check plugins.
+
+These iterate the discovered source-check plugins and aggregate the
+:class:`~.models.TeXFileIssue` objects they return.  No heuristics live here;
+with no plugin installed both runners return ``[]`` and preflight is unaffected.
+The discovered callables are cached so discovery does not run per file (the
+per-file runner is called in a tight loop over every TeX file).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .models import TeXFileIssue
+from .plugin_api import (
+    SOURCE_FILE_CHECKS_GROUP,
+    SOURCE_TREE_CHECKS_GROUP,
+    load_callables,
+    safe_call,
+)
+
+_file_checks: list[Callable] | None = None
+_tree_checks: list[Callable] | None = None
+
+
+def _file_check_callables() -> list[Callable]:
+    global _file_checks  # noqa: PLW0603
+    if _file_checks is None:
+        _file_checks = load_callables(SOURCE_FILE_CHECKS_GROUP)
+    return _file_checks
+
+
+def _tree_check_callables() -> list[Callable]:
+    global _tree_checks  # noqa: PLW0603
+    if _tree_checks is None:
+        _tree_checks = load_callables(SOURCE_TREE_CHECKS_GROUP)
+    return _tree_checks
+
+
+def reset_source_checks() -> None:
+    """Test hook: drop the cached plugin callables so the next call re-discovers."""
+    global _file_checks, _tree_checks  # noqa: PLW0603
+    _file_checks = None
+    _tree_checks = None
+
+
+def run_source_file_checks(filename: str, data: bytes) -> list[TeXFileIssue]:
+    """Run every per-file source-check plugin on one file's raw bytes."""
+    issues: list[TeXFileIssue] = []
+    for fn in _file_check_callables():
+        res = safe_call(fn, filename, data, default=[], label=f"source-file-check:{getattr(fn, '__name__', '?')}")
+        if res:
+            issues.extend(res)
+    return issues
+
+
+def run_source_tree_checks(tree_files: list[tuple[str, bytes]]) -> list[TeXFileIssue]:
+    """Run every whole-tree source-check plugin on a document tree."""
+    issues: list[TeXFileIssue] = []
+    for fn in _tree_check_callables():
+        res = safe_call(fn, tree_files, default=[], label=f"source-tree-check:{getattr(fn, '__name__', '?')}")
+        if res:
+            issues.extend(res)
+    return issues


### PR DESCRIPTION
Let preflight discover check implementations at runtime via Python entry points (importlib.metadata) instead of hard-coding them.  The public package now ships only the plugin *host* — the contract, discovery, and orchestration — plus the generic structural checks; sensitive detection heuristics can live in an external, privately-installed plugin and are picked up automatically when present.  With no plugin installed every group resolves empty and the checks no-op, so behaviour is unchanged for a bare install.

- plugin_api.py: CheckSpec contract + cached, fail-open entry-point loaders. Groups: tex2pdf_tools.preflight.{file_checks,pdf_checks,source_file_checks, source_tree_checks}.  Built-ins win on a name collision; a broken plugin is logged and skipped at both load and invocation time.
- source_checks.py: cached, fail-open runners for per-file and whole-tree source checks.
- file_checks.py / pdf_checks.py: FILE_CHECKS/PDF_CHECKS are now populated in place from the built-ins (no-exe, image-sizes, pdf-are-pdf / javascript) plus discovered plugins; check invocation is fail-open.  get_pdf_info() now exposes pdf_path so PDF-check plugins can open the file directly.
- __init__.py: run per-file source checks in parse_file, a whole-tree pass in the generator, attach PDF-only preflight warnings to the toplevel node, and set a generic "suspicious" status when a source check fires (opt-in via PREFLIGHT_SOURCE_SUSPICIOUS), keyed on a non-serialized flag rather than on any specific issue type.
- models.py: widen TeXFileIssue.key to `IssueType | str` so plugins can emit their own issue-type identifiers (kept out of the public enum); built-in keys remain IssueType members.
- feature_flags.py: add SOURCE_CHECK_SETS_SUSPICIOUS.
- tests: cover discovery, the built-ins-win policy, fail-open, the empty-registry no-op, and the suspicious-status wiring via an injected fake plugin.