### PR TITLE
ARXIVCE-4313: update copyright notice to arXiv, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) arXiv, Inc.
+Copyright (c) 2026 arXiv, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, arXiv
+Copyright (c) arXiv, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
⚠️ **DO NOT MERGE without checking with Jake Weiskoff (jake@arxiv.org) first.**
The copyright holder/year wording for ARXIVCE-4313 is not finalized. This PR is review-ready but must not be merged until Jake gives the go-ahead.

Part of the arXiv spinout from Cornell (ARXIVCE-4313). Updates the LICENSE copyright holder to `arXiv, Inc.` and drops the year, per direction to normalize all repos org-wide.