### PR TITLE
Fixes for preflight and complation

### DIFF
--- a/tex2pdf-service/tex2pdf/tex_to_pdf_converters.py
+++ b/tex2pdf-service/tex2pdf/tex_to_pdf_converters.py
@@ -434,7 +434,8 @@ class BaseConverter:
                     logger.debug(f"MISSING_CITE: {MISSING_CITE_RE} found in line {line}")
                     citation_missing = True
                 else:
-                    logger.debug(f"MISSING_CITE: {MISSING_CITE_RE} not found in line {line}")
+                    # logger.debug(f"MISSING_CITE: {MISSING_CITE_RE} not found in line {line}")
+                    pass
             run["iteration"] = iteration
             outcome.update({"runs": self.runs, "status": status, "step": step})
             if status == "success":

--- a/tex2pdf-tools/tests/preflight/test_preflight.py
+++ b/tex2pdf-tools/tests/preflight/test_preflight.py
@@ -822,9 +822,15 @@ def test_pdf_with_javascript():
     """Test detection of PDF file with javascript embedded."""
     dir_path = os.path.join(FIXTURE_DIR, "pdf-with-javascript")
     pf: PreflightResponse = generate_preflight_response(dir_path)
+    # javascript is a warning, so the submission still succeeds ...
     assert pf.status.key.value == "success"
     assert len(pf.detected_toplevel_files) == 1
     assert len(pf.tex_files) == 0
+    # ... but the finding is surfaced as a (non-blocking) issue on the PDF toplevel
+    tlf = pf.detected_toplevel_files[0]
+    assert [i.info for i in tlf.issues] == ["pdf-contains-js"]
+    assert tlf.issues[0].key.value == "pdf_javascript"
+    assert tlf.issues[0].filename == "main.pdf"
 
 def test_fontspec_font_detection():
     """Test detection of font files used by fontspec commands."""

--- a/tex2pdf-tools/tex2pdf_tools/preflight/models.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/models.py
@@ -94,6 +94,7 @@ class IssueType(str, Enum):
     bbl_usage_mismatch = "bbl_usage_mismatch"
     oversized_image = "oversized_image"
     pdf_not_pdf = "pdf_not_pdf"
+    pdf_javascript = "pdf_javascript"
     graphics_driver_option = "graphics_driver_option"
     graphics_driver_unsupported = "graphics_driver_unsupported"
     unsupported_zzrm_format = "unsupported_zzrm_format"

--- a/tex2pdf-tools/tex2pdf_tools/preflight/pdf_checks.py
+++ b/tex2pdf-tools/tex2pdf_tools/preflight/pdf_checks.py
@@ -1,11 +1,12 @@
 """This module implements QA checks for PDF files."""
 
+import os
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from .models import CheckResult, CheckSeverity, logger
+from .models import CheckResult, CheckSeverity, IssueType, TeXFileIssue, logger
 from .plugin_api import PDF_CHECKS_GROUP, merge_check_specs, safe_call
 
 
@@ -70,12 +71,23 @@ def check_javascript(res: dict, severity: CheckSeverity) -> CheckResult:
     # "returncode" should be always set, and if it is 0, stdout and stderr are also set
     if res["pdfinfo_js"]["returncode"] == 0 and res["pdfinfo_js"]["stdout"].strip():
         logger.debug("Detected JavaScript in PDF")
+        # Attach a TeXFileIssue so the finding surfaces through the preflight
+        # ``issues`` channel too (e.g. the single-PDF branch in parse_dir, which
+        # only forwards ``CheckResult.issues``), not just the compile-time
+        # ``problems`` channel which reads ``CheckResult.info``.
+        pdf_path = res.get("pdf_path")
+        info = "pdf-contains-js"
+        issue = TeXFileIssue(
+            IssueType.pdf_javascript,
+            info,
+            filename=os.path.basename(pdf_path) if pdf_path else None,
+        )
         return CheckResult(
             check_passed=False,
-            info="pdf-contains-js",
+            info=info,
             long_info=res["pdfinfo_js"]["stdout"],
             severity=severity,
-            issues=[],
+            issues=[issue],
         )
     return CheckResult(check_passed=True, info="", long_info="", severity=severity, issues=[])
 


### PR DESCRIPTION
- Don't spam logs for each line of TeX log file input
- surface an issue in preflight when a PDF only submission with javascript is submitted (does not happen, submit system already catches that, but still)