### PR TITLE
Fix watermark not being gray, and fix watermark tests

### DIFF
--- a/tex2pdf-service/tests/test_watermark.py
+++ b/tex2pdf-service/tests/test_watermark.py
@@ -71,6 +71,21 @@ def _core_ink_color(path: str) -> tuple[int, int, int]:
     return tuple(round(sum(channel) / len(ink)) for channel in zip(*ink))  # type: ignore[return-value]
 
 
+def _extracted_watermark_text(path: str) -> str:
+    """Reconstruct the watermark string from the first page.
+
+    The watermark is composited as a rotated (90°) Form XObject. pdf_oxide's
+    ``to_plain_text``/``extract_text`` drop such rotated-XObject spans during
+    reading-order assembly (they collapse to zero spans), so use
+    ``extract_chars`` -- which recovers every glyph via the font's ToUnicode
+    CMap -- and order the chars bottom-to-top (ascending ``origin_y``), the
+    direction the vertical watermark reads.
+    """
+    doc = pdf_oxide.PdfDocument(path)
+    chars = doc.extract_chars(0)
+    return "".join(c.char for c in sorted(chars, key=lambda c: c.origin_y))
+
+
 def _kpsewhich_font() -> str | None:
     """Return absolute path of CUSTOM_FONT_BASENAME via kpsewhich, else None."""
     if not shutil.which("kpsewhich"):
@@ -168,8 +183,7 @@ class TestCustomFont(unittest.TestCase):
         self.assertTrue(os.path.exists(out_path), f"{out_path} was not produced")
         self.assertGreater(os.path.getsize(out_path), 0)
         # The watermark text must be present and extractable on the first page.
-        doc = pdf_oxide.PdfDocument(out_path)
-        self.assertIn(text, doc.to_plain_text(0))
+        self.assertIn(text, _extracted_watermark_text(out_path))
         # The custom font must be embedded (subset) and carry a "Plex" base name.
         font_names = _embedded_font_basefonts(out_path)
         self.assertTrue(

--- a/tex2pdf-service/tests/test_watermark.py
+++ b/tex2pdf-service/tests/test_watermark.py
@@ -54,6 +54,23 @@ def _embedded_font_basefonts(path: str) -> set[str]:
     return names
 
 
+def _core_ink_color(path: str) -> tuple[int, int, int]:
+    """Return the average RGB of the watermark's core (non-antialiased) ink.
+
+    Renders page 0 at 150 dpi, restricts to the left-margin band where the
+    watermark sits, and averages only the strongly-inked pixels (channel sum
+    < 450) so anti-aliased edges near white do not skew the result.
+    """
+    doc = pdf_oxide.PdfDocument(path)
+    pixmap = doc.render_pixmap(0, dpi=150)
+    image = Image.frombytes("RGBA", (pixmap.width, pixmap.height), pixmap.data).convert("RGB")
+    strip = image.crop((0, 0, int(40 * 150 / 72), image.height))
+    ink = [p for p in strip.get_flattened_data() if sum(p) < 450]
+    if not ink:
+        raise AssertionError("no watermark ink found in the left margin")
+    return tuple(round(sum(channel) / len(ink)) for channel in zip(*ink))  # type: ignore[return-value]
+
+
 def _kpsewhich_font() -> str | None:
     """Return absolute path of CUSTOM_FONT_BASENAME via kpsewhich, else None."""
     if not shutil.which("kpsewhich"):
@@ -106,6 +123,30 @@ class MyTestCase(unittest.TestCase):
         self.assertAlmostEqual(
             center, page_height / 2.0, delta=60, msg=f"watermark not vertically centered: center {center:.0f} pt"
         )
+
+    def test_default_watermark_is_gray_not_black(self):
+        """The default watermark must render in #808080 gray, not full black.
+
+        Regression guard: pdf_oxide's inline_color() emits the glyphs without a
+        fill-color operator, so without _inject_fill_color the text would fall
+        back to the default black. Verify the stamped ink is the requested gray.
+        """
+        out_path = os.path.join(SELF_DIR, "output/Test_gray.pdf")
+        add_watermark_text_to_pdf(Watermark("arXiv:2601.00001", None), in_pdf, out_path)
+        r, g, b = _core_ink_color(out_path)
+        # #808080 == (128, 128, 128): neutral gray, clearly not black.
+        self.assertAlmostEqual(r, 128, delta=16, msg=f"ink not gray: {(r, g, b)}")
+        self.assertAlmostEqual(g, 128, delta=16, msg=f"ink not gray: {(r, g, b)}")
+        self.assertAlmostEqual(b, 128, delta=16, msg=f"ink not gray: {(r, g, b)}")
+
+    def test_watermark_color_is_honored(self):
+        """A caller-supplied fcolor must be reflected in the stamped ink."""
+        out_path = os.path.join(SELF_DIR, "output/Test_red.pdf")
+        add_watermark_text_to_pdf(Watermark("arXiv:2601.00001", None), in_pdf, out_path, fcolor="#ff0000")
+        r, g, b = _core_ink_color(out_path)
+        self.assertGreater(r, 200, f"red channel too low: {(r, g, b)}")
+        self.assertLess(g, 60, f"green channel too high: {(r, g, b)}")
+        self.assertLess(b, 60, f"blue channel too high: {(r, g, b)}")
 
 
 @unittest.skipUnless(_kpsewhich_font(), f"{CUSTOM_FONT_BASENAME} not found via kpsewhich")

--- a/tex2pdf-service/tex2pdf/pdf_watermark.py
+++ b/tex2pdf-service/tex2pdf/pdf_watermark.py
@@ -156,6 +156,14 @@ def _build_watermark_overlay(
     page.font(font_name, fsize).at(0.0, baseline).inline_color(rgb[0], rgb[1], rgb[2], text)
     overlay_pdf = bytes(page.done().build())
 
+    # pdf_oxide's inline_color() lays down the glyphs but emits no fill-color
+    # operator, so the text falls back to the default black. Relying on the
+    # graphics state inherited from the `Do` invocation does not help either --
+    # pdf_oxide's own renderer ignores inherited fill color inside Form
+    # XObjects. Bake the color into the overlay's content stream so it renders
+    # identically in every viewer.
+    overlay_pdf = _inject_fill_color(overlay_pdf, rgb)
+
     # Measure the actual drawn extent by rendering and finding the non-background
     # bounding box. This is font-agnostic and exact, unlike base-14 metrics.
     scale = _INK_DPI / 72.0
@@ -169,6 +177,24 @@ def _build_watermark_overlay(
     else:
         ink = (bbox[0] / scale, bbox[1] / scale, bbox[2] / scale, bbox[3] / scale)
     return overlay_pdf, ink
+
+
+def _inject_fill_color(overlay_pdf: bytes, rgb: tuple[float, float, float]) -> bytes:
+    """Prepend a fill-color (``r g b rg``) operator to the overlay content stream.
+
+    pdf_oxide's ``inline_color`` does not currently emit a color operator, so the
+    watermark glyphs would otherwise render in the default black. Prepending the
+    fill color makes the color intrinsic to the watermark page instead of relying
+    on inherited graphics state (which pdf_oxide's renderer ignores for Form
+    XObjects). pikepdf's save is deterministic, so this keeps output reproducible.
+    """
+    with pikepdf.open(io.BytesIO(overlay_pdf)) as doc:
+        page = pikepdf.Page(doc.pages[0])
+        color_op = f"{rgb[0]:.4f} {rgb[1]:.4f} {rgb[2]:.4f} rg\n".encode()
+        page.contents_add(color_op, prepend=True)
+        out = io.BytesIO()
+        doc.save(out)
+        return out.getvalue()
 
 
 def _watermark_should_overlay(


### PR DESCRIPTION
The rewrite of the watermark code from pymupdf to pdf_oxide broke
watermark color due to insufficiencies of the pdf_oxide library.

Fix the color by injecting the color code, add unittests for the 
watermark color.

Fix also other failing watermark tests.