### PR TITLE
[remote_call] retry 503 from the compile service like 504

### DIFF
--- a/tex2pdf-service/tex2pdf/remote_call.py
+++ b/tex2pdf-service/tex2pdf/remote_call.py
@@ -123,9 +123,12 @@ def convert_pdf_remote(
                     return 422, "Failed to submit tarball: connection error"
                 status_code = res.status_code
                 logger.debug("Received status code %d from POST to %s", status_code, res.url, extra=log_extra)
-                if status_code == 504:
+                if status_code in (503, 504):
                     # This is the only place we retry, and at most 3 times in total.
-                    logger.warning("Got 504 for %s", compile_service, extra=log_extra)
+                    # 503 is what Cloud Run answers with when it cannot hand the
+                    # request to a container (cold start, scale-out). Relaying it
+                    # to the caller ends the compilation, so absorb it here.
+                    logger.warning("Got %d for %s", status_code, compile_service, extra=log_extra)
                     time.sleep(1)
                     # we need to rewind the data_fd otherwise the next request will send
                     # an empty file.


### PR DESCRIPTION
Cloud Run answers 503 when it cannot hand a request to a container (cold start, scale-out). service_process_tarball only retried 504 and relayed everything else to the caller as "Unexpected status code: 503", which ends the compilation.

For submissions that is worse than a lost compilation: compile_at_gcp persists the merged ZZRM as 00README.json only after a successful compile, so a submission that hits this keeps whatever 00README it arrived with, and publish then compiles it with AutoTeX/TL2023 instead of at GCP. Seen on submit/7875560.

The existing rewind of data_fd already covers the added case.